### PR TITLE
fix: edge-case correctness bugs (count=1 crash, hue=360 round-trip)

### DIFF
--- a/src/ColorSpaceConverter.php
+++ b/src/ColorSpaceConverter.php
@@ -51,9 +51,13 @@ class ColorSpaceConverter
             }
 
             $h = round($h * 60);
-            if ($h < 0) {
-                $h += ValidationConstants::HUE_MAX;
-            }
+        }
+
+        // Normalize hue into the documented [0, 360) range. round() can land
+        // exactly on 360 (e.g. rgb(255, 0, 1)), which is out of range.
+        $h = fmod((float) $h, ValidationConstants::HUE_MAX);
+        if ($h < 0) {
+            $h += ValidationConstants::HUE_MAX;
         }
 
         return [
@@ -155,6 +159,13 @@ class ColorSpaceConverter
                 $h = ($r - $g) / $d + 4;
             }
             $h = round($h * 60);
+        }
+
+        // Normalize hue into the documented [0, 360) range so the result is
+        // always a valid fromHsv() input (round() can produce exactly 360).
+        $h = fmod((float) $h, ValidationConstants::HUE_MAX);
+        if ($h < 0) {
+            $h += ValidationConstants::HUE_MAX;
         }
 
         return [

--- a/src/Strategies/MonochromaticStrategy.php
+++ b/src/Strategies/MonochromaticStrategy.php
@@ -23,6 +23,11 @@ class MonochromaticStrategy extends AbstractPaletteStrategy
     public function generate(ColorInterface $baseColor, array $options = []): ColorPalette
     {
         $count = $this->getCountOption($options, 5);
+
+        if ($count === 1) {
+            return new ColorPalette([$baseColor]);
+        }
+
         $colors = [$baseColor];
         $hsl = $baseColor->toHsl();
         $step = ColorSchemeConstants::DEFAULT_MANIPULATION_STEP / ($count - 1);

--- a/src/Strategies/ShadesStrategy.php
+++ b/src/Strategies/ShadesStrategy.php
@@ -22,6 +22,11 @@ class ShadesStrategy extends AbstractPaletteStrategy
     public function generate(ColorInterface $baseColor, array $options = []): ColorPalette
     {
         $count = $this->getCountOption($options, 5);
+
+        if ($count === 1) {
+            return new ColorPalette([$baseColor]);
+        }
+
         $colors = [$baseColor];
         $step = ColorSchemeConstants::DEFAULT_MANIPULATION_STEP / ($count - 1);
 

--- a/src/Strategies/TintsStrategy.php
+++ b/src/Strategies/TintsStrategy.php
@@ -22,6 +22,11 @@ class TintsStrategy extends AbstractPaletteStrategy
     public function generate(ColorInterface $baseColor, array $options = []): ColorPalette
     {
         $count = $this->getCountOption($options, 5);
+
+        if ($count === 1) {
+            return new ColorPalette([$baseColor]);
+        }
+
         $colors = [$baseColor];
         $step = ColorSchemeConstants::DEFAULT_MANIPULATION_STEP / ($count - 1);
 

--- a/tests/Unit/ColorSpaceConverterHueTest.php
+++ b/tests/Unit/ColorSpaceConverterHueTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+use Farzai\ColorPalette\Color;
+use Farzai\ColorPalette\ColorSpaceConverter;
+
+/**
+ * Regression: round($h * 60) can land exactly on 360 (e.g. rgb(255, 0, 1)), but
+ * the code only wrapped negative hues. That violated the documented [0, 360) range
+ * and made toHsv() emit a hue that fromHsv() then rejected, breaking the round-trip.
+ */
+describe('ColorSpaceConverter hue normalization', function () {
+    // A handful of colors whose raw hue rounds up to exactly 360 degrees.
+    $hueWrapColors = [
+        [255, 0, 1],
+        [255, 0, 2],
+        [200, 0, 1],
+    ];
+
+    foreach ($hueWrapColors as $rgb) {
+        [$r, $g, $b] = $rgb;
+
+        test("toHsl({$r},{$g},{$b}) keeps hue within [0, 360)", function () use ($r, $g, $b) {
+            $hsl = ColorSpaceConverter::toHsl(new Color($r, $g, $b));
+
+            expect($hsl['h'])->toBeGreaterThanOrEqual(0);
+            expect($hsl['h'])->toBeLessThan(360);
+        });
+
+        test("toHsv({$r},{$g},{$b}) keeps hue within [0, 360)", function () use ($r, $g, $b) {
+            $hsv = ColorSpaceConverter::toHsv(new Color($r, $g, $b));
+
+            expect($hsv['h'])->toBeGreaterThanOrEqual(0);
+            expect($hsv['h'])->toBeLessThan(360);
+        });
+
+        test("toHsv({$r},{$g},{$b}) output is a valid fromHsv() input (round-trip does not throw)", function () use ($r, $g, $b) {
+            $hsv = ColorSpaceConverter::toHsv(new Color($r, $g, $b));
+
+            $result = ColorSpaceConverter::fromHsv($hsv['h'], $hsv['s'], $hsv['v']);
+
+            expect($result)->toBeInstanceOf(Color::class);
+        });
+    }
+});

--- a/tests/Unit/Strategies/StrategyCountBoundaryTest.php
+++ b/tests/Unit/Strategies/StrategyCountBoundaryTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+use Farzai\ColorPalette\Color;
+use Farzai\ColorPalette\ColorPalette;
+use Farzai\ColorPalette\Strategies\MonochromaticStrategy;
+use Farzai\ColorPalette\Strategies\ShadesStrategy;
+use Farzai\ColorPalette\Strategies\TintsStrategy;
+
+/**
+ * Regression: count-based strategies computed `step = X / (count - 1)` before the
+ * loop, so count=1 (a value MIN_COUNT=1 explicitly allows) threw DivisionByZeroError.
+ */
+describe('Count-based strategies handle count=1 without dividing by zero', function () {
+    $strategies = [
+        'monochromatic' => fn () => new MonochromaticStrategy,
+        'shades' => fn () => new ShadesStrategy,
+        'tints' => fn () => new TintsStrategy,
+    ];
+
+    foreach ($strategies as $name => $make) {
+        test("{$name} returns a single-color palette of the base color when count=1", function () use ($make) {
+            $strategy = $make();
+            $baseColor = new Color(120, 80, 40);
+
+            $palette = $strategy->generate($baseColor, ['count' => 1]);
+
+            expect($palette)->toBeInstanceOf(ColorPalette::class);
+            expect($palette->count())->toBe(1);
+            expect($palette->getColors()[0])->toBe($baseColor);
+        });
+    }
+});


### PR DESCRIPTION
Part of a multi-PR pass following a full code review. **Backward-compatible**, no API changes.

## Bugs fixed

### 1. `DivisionByZeroError` when `count = 1`
`MonochromaticStrategy`, `ShadesStrategy`, and `TintsStrategy` computed `step = DEFAULT_MANIPULATION_STEP / ($count - 1)` *before* the loop, so `count = 1` (a value `MIN_COUNT = 1` explicitly allows) threw `DivisionByZeroError`.
Reachable via `PaletteGenerator::monochromatic(1)` and `ColorPalette::fromColor($c, 'shades', ['count' => 1])`.
**Fix:** guard `count = 1` to return a single-color palette of the base color.

### 2. `toHsl()` / `toHsv()` could return `hue = 360`
`round($h * 60)` can land exactly on 360 (e.g. `rgb(255, 0, 1)`), but only negative hues were wrapped. This violated the documented `[0, 360)` range **and** made `toHsv()` emit a hue that `fromHsv()` rejects — breaking the `toHsv → fromHsv` round-trip.
**Fix:** `fmod`-based normalization into `[0, 360)` in both methods.

## Tests (TDD — written failing first)
- `tests/Unit/Strategies/StrategyCountBoundaryTest.php` — `count = 1` for all three strategies
- `tests/Unit/ColorSpaceConverterHueTest.php` — hue stays in `[0, 360)` + round-trip does not throw

Full suite: **940 passed, 37 skipped** (Imagick/GD-disabled skip locally).