### PR TITLE
feat(security): guard image decoding against decompression bombs + Imagick validation parity

### DIFF
--- a/src/Constants/ImageConstants.php
+++ b/src/Constants/ImageConstants.php
@@ -20,6 +20,21 @@ class ImageConstants
     public const MAX_IMAGE_FILE_SIZE = 10 * 1024 * 1024; // 10 MB
 
     /**
+     * Maximum allowed decoded image dimensions
+     *
+     * The file-size cap above bounds bytes on disk, NOT the size of the decoded
+     * bitmap: a small, highly-compressed image (a "decompression bomb") can
+     * inflate to billions of pixels and exhaust memory. These limits are checked
+     * against the image header (via getimagesize) BEFORE any decoder loads the
+     * pixels, capping both each side and the total pixel count.
+     */
+    public const MAX_IMAGE_WIDTH = 12000;
+
+    public const MAX_IMAGE_HEIGHT = 12000;
+
+    public const MAX_IMAGE_PIXELS = 50_000_000; // ~50 megapixels
+
+    /**
      * Allowed MIME types for image uploads
      *
      * Only these image formats are supported for color extraction.

--- a/src/ImageFactory.php
+++ b/src/ImageFactory.php
@@ -83,6 +83,13 @@ class ImageFactory
     {
         $this->getExtensionChecker()->ensureImagickLoaded();
 
+        if (! file_exists($path)) {
+            throw new InvalidArgumentException("Image file not found: {$path}");
+        }
+
+        // Apply the same size/MIME/dimension guards as the GD path before decoding.
+        $this->validateImageFile($path);
+
         try {
             /** @var \Imagick $image */
             $image = new \Imagick($path);
@@ -122,6 +129,10 @@ class ImageFactory
             );
         }
 
+        // Guard against decompression bombs before any decoder loads the bitmap.
+        // Runs regardless of finfo availability since getimagesize reads only the header.
+        $this->validateImageDimensions($path);
+
         // Check MIME type
         if (! function_exists('finfo_open')) {
             // finfo not available, skip MIME check
@@ -146,6 +157,51 @@ class ImageFactory
                     'Unsupported image MIME type: %s. Allowed types: %s',
                     $mimeType,
                     implode(', ', ImageConstants::ALLOWED_IMAGE_MIME_TYPES)
+                )
+            );
+        }
+    }
+
+    /**
+     * Validate decoded image dimensions to prevent decompression-bomb / pixel-flood DoS
+     *
+     * Reads dimensions from the image header (getimagesize) without decoding the
+     * pixel data, then rejects images that exceed the per-side or total-pixel caps.
+     *
+     * @param  string  $path  Path to the image file
+     *
+     * @throws InvalidArgumentException If dimensions are unreadable or too large
+     */
+    private function validateImageDimensions(string $path): void
+    {
+        $dimensions = @getimagesize($path);
+
+        if ($dimensions === false) {
+            throw new InvalidArgumentException(
+                "Unable to read image dimensions (file may not be a supported image): {$path}"
+            );
+        }
+
+        [$width, $height] = $dimensions;
+
+        if ($width <= 0 || $height <= 0) {
+            throw new InvalidArgumentException(
+                sprintf('Invalid image dimensions: %dx%d', $width, $height)
+            );
+        }
+
+        if ($width > ImageConstants::MAX_IMAGE_WIDTH
+            || $height > ImageConstants::MAX_IMAGE_HEIGHT
+            || ($width * $height) > ImageConstants::MAX_IMAGE_PIXELS) {
+            throw new InvalidArgumentException(
+                sprintf(
+                    'Image dimensions too large: %dx%d (%d pixels). Maximum allowed: %dx%d or %d pixels.',
+                    $width,
+                    $height,
+                    $width * $height,
+                    ImageConstants::MAX_IMAGE_WIDTH,
+                    ImageConstants::MAX_IMAGE_HEIGHT,
+                    ImageConstants::MAX_IMAGE_PIXELS
                 )
             );
         }

--- a/tests/Unit/ImageFactorySecurityTest.php
+++ b/tests/Unit/ImageFactorySecurityTest.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+use Farzai\ColorPalette\Constants\ImageConstants;
+use Farzai\ColorPalette\ImageFactory;
+use Farzai\ColorPalette\Images\GdImage;
+
+/**
+ * Build a minimal, byte-tiny PNG whose IHDR *declares* the given dimensions.
+ * getimagesize() reads width/height straight from IHDR without decoding any
+ * pixels, so this is exactly the shape of a decompression bomb: a few bytes
+ * on disk that would allocate billions of pixels if a decoder ran.
+ */
+function fakePngWithDimensions(int $width, int $height): string
+{
+    $signature = "\x89PNG\r\n\x1a\n";
+
+    $ihdrData = pack('N', $width).pack('N', $height)."\x08\x02\x00\x00\x00"; // 8-bit, truecolor
+    $ihdr = pack('N', strlen($ihdrData)).'IHDR'.$ihdrData.pack('N', crc32('IHDR'.$ihdrData));
+
+    $iend = pack('N', 0).'IEND'.pack('N', crc32('IEND'));
+
+    return $signature.$ihdr.$iend;
+}
+
+function writeTempImage(string $bytes, string $suffix = '.png'): string
+{
+    $path = tempnam(sys_get_temp_dir(), 'imgtest_').$suffix;
+    file_put_contents($path, $bytes);
+
+    return $path;
+}
+
+describe('ImageFactory decompression-bomb / pixel-flood guard', function () {
+    test('it rejects an image whose declared dimensions exceed the pixel cap', function () {
+        // ~6.4 gigapixels declared in a handful of bytes on disk.
+        $path = writeTempImage(fakePngWithDimensions(80000, 80000));
+
+        try {
+            expect(fn () => ImageFactory::fromPath($path, 'gd'))
+                ->toThrow(InvalidArgumentException::class, 'dimensions too large');
+        } finally {
+            @unlink($path);
+        }
+    });
+
+    test('it rejects an image whose width exceeds the per-dimension cap', function () {
+        $path = writeTempImage(fakePngWithDimensions(ImageConstants::MAX_IMAGE_WIDTH + 1, 10));
+
+        try {
+            expect(fn () => ImageFactory::fromPath($path, 'gd'))
+                ->toThrow(InvalidArgumentException::class, 'dimensions too large');
+        } finally {
+            @unlink($path);
+        }
+    });
+
+    test('it still loads a normal, small image', function () {
+        $gd = imagecreatetruecolor(4, 4);
+        $path = tempnam(sys_get_temp_dir(), 'imgok_').'.png';
+        imagepng($gd, $path);
+        unset($gd); // GD images are auto-freed objects since PHP 8.0
+
+        try {
+            $image = ImageFactory::fromPath($path, 'gd');
+            expect($image)->toBeInstanceOf(GdImage::class);
+            expect($image->getWidth())->toBe(4);
+        } finally {
+            @unlink($path);
+        }
+    });
+});
+
+describe('ImageFactory Imagick path validation parity', function () {
+    test('the Imagick path rejects oversized dimensions like the GD path', function () {
+        if (! extension_loaded('imagick')) {
+            $this->markTestSkipped('Imagick extension is not available.');
+        }
+
+        $path = writeTempImage(fakePngWithDimensions(80000, 80000));
+
+        try {
+            expect(fn () => ImageFactory::fromPath($path, 'imagick'))
+                ->toThrow(InvalidArgumentException::class, 'dimensions too large');
+        } finally {
+            @unlink($path);
+        }
+    });
+
+    test('the Imagick path rejects a non-image file (size/MIME validation runs)', function () {
+        if (! extension_loaded('imagick')) {
+            $this->markTestSkipped('Imagick extension is not available.');
+        }
+
+        $path = writeTempImage('this is definitely not an image', '.png');
+
+        try {
+            expect(fn () => ImageFactory::fromPath($path, 'imagick'))
+                ->toThrow(InvalidArgumentException::class);
+        } finally {
+            @unlink($path);
+        }
+    });
+});


### PR DESCRIPTION
Part of the multi-PR review pass. **Backward-compatible** (adds rejection of malicious oversized images; normal images are unaffected).

## What & why

### Decompression-bomb / pixel-flood guard
`MAX_IMAGE_FILE_SIZE` (10 MB) caps *bytes on disk*, but `imagecreatefromstring()` / `new \Imagick()` decode the **full bitmap** into memory first. A small, highly-compressed image can declare billions of pixels and OOM the process — the file-size cap does nothing against it.

**Fix:** new caps `MAX_IMAGE_WIDTH`/`MAX_IMAGE_HEIGHT` (12000) and `MAX_IMAGE_PIXELS` (50 MP), validated via `getimagesize()` (reads only the header — no pixel decode) **before** decoding. Applies to both local-file and URL (temp-file) loads.

### Imagick path validation parity
`createImagickImage()` previously skipped the `validateImageFile()` size+MIME checks that `createGdImage()` ran — even though Imagick is the default preferred driver and the higher-risk decoder. It now runs the same `file_exists` + size + MIME + dimension guards before constructing `\Imagick`.

## Tests (TDD — failing first)
`tests/Unit/ImageFactorySecurityTest.php`:
- crafts a byte-tiny PNG whose IHDR *declares* 80000×80000 → rejected with "dimensions too large"
- per-dimension cap rejection
- a normal 4×4 image still loads
- Imagick parity tests (skip when ext unavailable; CI runs them)

Full suite: **942 passed, 39 skipped**, no new deprecations. Pint clean on changed files.

## Residual (tracked separately)
DNS-rebinding/TOCTOU and redirect re-validation are handled in a follow-up PR.