### PR TITLE
feat(security): re-validate every redirect hop against SSRF rules

### DIFF
--- a/src/ImageLoader.php
+++ b/src/ImageLoader.php
@@ -13,6 +13,7 @@ use Farzai\ColorPalette\Exceptions\SsrfException;
 use Farzai\ColorPalette\Services\ExtensionChecker;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;
 
 class ImageLoader
@@ -90,11 +91,11 @@ class ImageLoader
         $tempFile = null;
 
         try {
-            // Create request with User-Agent header
-            $request = $this->requestFactory->createRequest('GET', $url)
-                ->withHeader('User-Agent', $this->httpConfig->getUserAgent());
-
-            $response = $this->httpClient->sendRequest($request);
+            // Follow redirects ourselves, re-validating every hop against the
+            // SSRF rules. The underlying client must NOT auto-follow (the factory
+            // forces max_redirects=0) or a redirect to an internal address would
+            // never reach validateUrl().
+            $response = $this->sendRequestFollowingRedirects($url);
 
             // Accept all 2xx status codes
             $statusCode = $response->getStatusCode();
@@ -154,6 +155,102 @@ class ImageLoader
 
             throw new HttpException("Failed to load image from URL: {$url}", 0, $e);
         }
+    }
+
+    /**
+     * Send a GET request, manually following redirects with per-hop SSRF validation
+     *
+     * Every redirect target is resolved to an absolute URL and re-checked with
+     * validateUrl() before it is fetched, so an attacker cannot use a redirect to
+     * reach a private/reserved address. The number of hops is bounded by the
+     * configured maxRedirects; with the default of 0, redirect responses are
+     * returned unfollowed and rejected by the caller's status-code check.
+     *
+     * @throws HttpException If the redirect budget is exceeded
+     * @throws SsrfException If a redirect target points to a private/reserved host
+     */
+    private function sendRequestFollowingRedirects(string $url): ResponseInterface
+    {
+        $maxRedirects = $this->httpConfig->getMaxRedirects();
+        $currentUrl = $url;
+
+        for ($redirect = 0; ; $redirect++) {
+            $request = $this->requestFactory->createRequest('GET', $currentUrl)
+                ->withHeader('User-Agent', $this->httpConfig->getUserAgent());
+
+            $response = $this->httpClient->sendRequest($request);
+
+            $status = $response->getStatusCode();
+
+            // Not a redirect: this is the final response.
+            if ($status < 300 || $status >= 400) {
+                return $response;
+            }
+
+            if ($redirect >= $maxRedirects) {
+                // Not following (budget exhausted). With maxRedirects=0 we hand the
+                // redirect back so the status check rejects it; otherwise it's an error.
+                if ($maxRedirects === 0) {
+                    return $response;
+                }
+
+                throw new HttpException(
+                    sprintf('Too many redirects (max: %d) while loading image from URL: %s', $maxRedirects, $url)
+                );
+            }
+
+            if (! $response->hasHeader('Location')) {
+                return $response;
+            }
+
+            $nextUrl = $this->resolveRedirectUrl($currentUrl, $response->getHeaderLine('Location'));
+
+            // Re-validate every hop so a redirect cannot bypass SSRF protection.
+            $this->validateUrl($nextUrl);
+
+            $currentUrl = $nextUrl;
+        }
+    }
+
+    /**
+     * Resolve a (possibly relative) redirect Location against the current URL
+     */
+    private function resolveRedirectUrl(string $baseUrl, string $location): string
+    {
+        $location = trim($location);
+
+        if ($location === '') {
+            throw new HttpException('Redirect response is missing a Location target');
+        }
+
+        // Already an absolute http(s) URL.
+        if (preg_match('#^https?://#i', $location) === 1) {
+            return $location;
+        }
+
+        $base = parse_url($baseUrl);
+        if ($base === false || ! isset($base['scheme'], $base['host'])) {
+            throw new HttpException('Cannot resolve a relative redirect against an invalid base URL');
+        }
+
+        $authority = $base['scheme'].'://'.$base['host'].(isset($base['port']) ? ':'.$base['port'] : '');
+
+        // Scheme-relative: //host/path
+        if (str_starts_with($location, '//')) {
+            return $base['scheme'].':'.$location;
+        }
+
+        // Absolute path: /path
+        if (str_starts_with($location, '/')) {
+            return $authority.$location;
+        }
+
+        // Relative path: resolve against the base path's directory.
+        $basePath = $base['path'] ?? '/';
+        $slash = strrpos($basePath, '/');
+        $dir = $slash === false ? '/' : substr($basePath, 0, $slash + 1);
+
+        return $authority.$dir.$location;
     }
 
     private function createTempFile(): string

--- a/src/ImageLoaderFactory.php
+++ b/src/ImageLoaderFactory.php
@@ -46,7 +46,11 @@ class ImageLoaderFactory
     {
         $symfonyClient = HttpClient::create([
             'timeout' => $config->getTimeoutSeconds(),
-            'max_redirects' => $config->getMaxRedirects(),
+            // Never auto-follow redirects at the transport layer: ImageLoader follows
+            // them itself and re-validates each hop against the SSRF rules. Letting the
+            // client follow internally would skip that check (the config's maxRedirects
+            // is the budget ImageLoader uses for validated following).
+            'max_redirects' => 0,
             'verify_peer' => $config->shouldVerifySsl(),
             'verify_host' => $config->shouldVerifySsl(),
             'headers' => [

--- a/tests/Unit/ImageLoaderRedirectTest.php
+++ b/tests/Unit/ImageLoaderRedirectTest.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+use Farzai\ColorPalette\Config\HttpClientConfig;
+use Farzai\ColorPalette\Contracts\ImageInterface;
+use Farzai\ColorPalette\Exceptions\HttpException;
+use Farzai\ColorPalette\Exceptions\SsrfException;
+use Farzai\ColorPalette\ImageLoader;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamInterface;
+
+/**
+ * Redirects are followed by ImageLoader itself (not the transport), and every hop
+ * is re-checked against the SSRF rules. Public IP literals are used as the initial
+ * URL so validateUrl() never needs DNS (no network dependency in these tests).
+ */
+describe('ImageLoader redirect SSRF re-validation', function () {
+    test('it blocks a redirect whose target is a private/reserved address', function () {
+        $httpClient = Mockery::mock(ClientInterface::class);
+        $requestFactory = Mockery::mock(RequestFactoryInterface::class);
+        $request = Mockery::mock(RequestInterface::class);
+        $redirect = Mockery::mock(ResponseInterface::class);
+
+        $requestFactory->shouldReceive('createRequest')->andReturn($request);
+        $request->shouldReceive('withHeader')->andReturnSelf();
+        $httpClient->shouldReceive('sendRequest')->andReturn($redirect);
+        $redirect->shouldReceive('getStatusCode')->andReturn(302);
+        $redirect->shouldReceive('hasHeader')->with('Location')->andReturn(true);
+        $redirect->shouldReceive('getHeaderLine')->with('Location')
+            ->andReturn('http://169.254.169.254/latest/meta-data/'); // cloud metadata
+
+        $config = new HttpClientConfig(maxRedirects: 3);
+        $loader = new ImageLoader($httpClient, $requestFactory, httpConfig: $config);
+
+        expect(fn () => $loader->load('http://8.8.8.8/image.jpg'))
+            ->toThrow(SsrfException::class, 'private/reserved');
+    });
+
+    test('it does not follow redirects by default (maxRedirects=0)', function () {
+        $httpClient = Mockery::mock(ClientInterface::class);
+        $requestFactory = Mockery::mock(RequestFactoryInterface::class);
+        $request = Mockery::mock(RequestInterface::class);
+        $redirect = Mockery::mock(ResponseInterface::class);
+
+        $requestFactory->shouldReceive('createRequest')->andReturn($request);
+        $request->shouldReceive('withHeader')->andReturnSelf();
+        $httpClient->shouldReceive('sendRequest')->andReturn($redirect);
+        $redirect->shouldReceive('getStatusCode')->andReturn(302);
+
+        // Default config => maxRedirects=0 => the 3xx is returned unfollowed and
+        // rejected by the status-code check.
+        $loader = new ImageLoader($httpClient, $requestFactory);
+
+        expect(fn () => $loader->load('http://8.8.8.8/image.jpg'))
+            ->toThrow(HttpException::class, 'HTTP status code: 302');
+    });
+
+    test('it errors when the redirect budget is exceeded', function () {
+        $httpClient = Mockery::mock(ClientInterface::class);
+        $requestFactory = Mockery::mock(RequestFactoryInterface::class);
+        $request = Mockery::mock(RequestInterface::class);
+        $redirect = Mockery::mock(ResponseInterface::class);
+
+        $requestFactory->shouldReceive('createRequest')->andReturn($request);
+        $request->shouldReceive('withHeader')->andReturnSelf();
+        $httpClient->shouldReceive('sendRequest')->andReturn($redirect);
+        $redirect->shouldReceive('getStatusCode')->andReturn(302);
+        $redirect->shouldReceive('hasHeader')->with('Location')->andReturn(true);
+        $redirect->shouldReceive('getHeaderLine')->with('Location')->andReturn('http://1.1.1.1/next.jpg');
+
+        $config = new HttpClientConfig(maxRedirects: 2);
+        $loader = new ImageLoader($httpClient, $requestFactory, httpConfig: $config);
+
+        expect(fn () => $loader->load('http://8.8.8.8/image.jpg'))
+            ->toThrow(HttpException::class, 'Too many redirects');
+    });
+
+    test('it follows a redirect to a public target and loads the image', function () {
+        $httpClient = Mockery::mock(ClientInterface::class);
+        $requestFactory = Mockery::mock(RequestFactoryInterface::class);
+        $request = Mockery::mock(RequestInterface::class);
+        $redirect = Mockery::mock(ResponseInterface::class);
+        $final = Mockery::mock(ResponseInterface::class);
+        $stream = Mockery::mock(StreamInterface::class);
+
+        $requestFactory->shouldReceive('createRequest')->andReturn($request);
+        $request->shouldReceive('withHeader')->andReturnSelf();
+        // First call -> redirect, second call -> final 200.
+        $httpClient->shouldReceive('sendRequest')->andReturn($redirect, $final);
+
+        $redirect->shouldReceive('getStatusCode')->andReturn(301);
+        $redirect->shouldReceive('hasHeader')->with('Location')->andReturn(true);
+        $redirect->shouldReceive('getHeaderLine')->with('Location')->andReturn('http://1.1.1.1/final.jpg');
+
+        $final->shouldReceive('getStatusCode')->andReturn(200);
+        $final->shouldReceive('hasHeader')->with('Content-Length')->andReturn(false);
+        $final->shouldReceive('hasHeader')->with('Content-Type')->andReturn(true);
+        $final->shouldReceive('getHeaderLine')->with('Content-Type')->andReturn('image/jpeg');
+        $final->shouldReceive('getBody')->andReturn($stream);
+
+        $imageBytes = file_get_contents(__DIR__.'/../../example/assets/sample.jpg');
+        $stream->shouldReceive('eof')->andReturn(false, true);
+        $stream->shouldReceive('read')->with(8192)->andReturn($imageBytes);
+
+        $config = new HttpClientConfig(maxRedirects: 3);
+        $loader = new ImageLoader($httpClient, $requestFactory, httpConfig: $config);
+
+        $image = $loader->load('http://8.8.8.8/image.jpg');
+
+        expect($image)->toBeInstanceOf(ImageInterface::class);
+    });
+});
+
+describe('ImageLoader redirect URL resolution', function () {
+    test('it resolves an absolute-path redirect against the base host and re-validates it', function () {
+        // Redirecting to /admin on a host that resolves to a private address must be blocked.
+        $httpClient = Mockery::mock(ClientInterface::class);
+        $requestFactory = Mockery::mock(RequestFactoryInterface::class);
+        $request = Mockery::mock(RequestInterface::class);
+        $redirect = Mockery::mock(ResponseInterface::class);
+
+        $requestFactory->shouldReceive('createRequest')->andReturn($request);
+        $request->shouldReceive('withHeader')->andReturnSelf();
+        $httpClient->shouldReceive('sendRequest')->andReturn($redirect);
+        $redirect->shouldReceive('getStatusCode')->andReturn(302);
+        $redirect->shouldReceive('hasHeader')->with('Location')->andReturn(true);
+        // Scheme-relative redirect to a loopback address.
+        $redirect->shouldReceive('getHeaderLine')->with('Location')->andReturn('//127.0.0.1/secret');
+
+        $config = new HttpClientConfig(maxRedirects: 3);
+        $loader = new ImageLoader($httpClient, $requestFactory, httpConfig: $config);
+
+        expect(fn () => $loader->load('http://8.8.8.8/image.jpg'))
+            ->toThrow(SsrfException::class, 'private/reserved');
+    });
+});


### PR DESCRIPTION
Part of the multi-PR review pass. Closes the redirect-based SSRF bypass.

## Problem
`validateUrl()` validated only the **initial** URL. The factory passed `HttpClientConfig::maxRedirects` straight to the Symfony client, so raising it made the **transport** follow redirects internally and **unvalidated** — a server could `302 → http://169.254.169.254/` (cloud metadata) or `→ http://127.0.0.1/` and sail past the SSRF guard.

## Fix
- The transport client is pinned to `max_redirects = 0` (never auto-follows).
- `ImageLoader` follows redirects itself: it resolves each `Location` (absolute, scheme-relative, absolute-path, relative-path) to an absolute URL and re-runs `validateUrl()` **on every hop** before fetching.
- `HttpClientConfig::maxRedirects` now means "validated-follow budget". **Default (0) is behaviourally unchanged** — redirect responses are returned unfollowed and rejected by the existing status check (the `HTTP status code: 3xx` test still passes).

## Tests (TDD)
`tests/Unit/ImageLoaderRedirectTest.php` (public IP literals → no DNS/network):
- redirect to a private/reserved IP → `SsrfException`
- scheme-relative redirect `//127.0.0.1/…` resolved + blocked
- default `maxRedirects=0` does not follow
- redirect budget exceeded → `HttpException: Too many redirects`
- legitimate redirect to a public target → image loads

Full suite: **948 passed, 39 skipped**. Pint clean.

## Residual (documented, not fixed here)
- **DNS rebinding / TOCTOU**: `validateUrl()` resolves DNS, then the transport resolves again at fetch time. Truly closing this needs IP-pinning at the socket layer, which PSR-18 abstracts away.
- A caller injecting its **own** redirect-following PSR-18 client bypasses this (inherent to PSR-18). The factory-built loader is safe.