### PR TITLE
refactor(color): eliminate triplicated color logic (single source of truth)

### DIFF
--- a/src/Color.php
+++ b/src/Color.php
@@ -4,18 +4,17 @@ declare(strict_types=1);
 
 namespace Farzai\ColorPalette;
 
-use Farzai\ColorPalette\Constants\AccessibilityConstants;
 use Farzai\ColorPalette\Constants\ValidationConstants;
 use Farzai\ColorPalette\Contracts\ColorInterface;
 use InvalidArgumentException;
 
 class Color implements ColorInterface
 {
-    private int $red;
+    private readonly int $red;
 
-    private int $green;
+    private readonly int $green;
 
-    private int $blue;
+    private readonly int $blue;
 
     public function __construct(int $red, int $green, int $blue)
     {
@@ -151,91 +150,57 @@ class Color implements ColorInterface
 
     public function getBrightness(): float
     {
-        return (($this->red * AccessibilityConstants::BRIGHTNESS_RED_COEFFICIENT) +
-                ($this->green * AccessibilityConstants::BRIGHTNESS_GREEN_COEFFICIENT) +
-                ($this->blue * AccessibilityConstants::BRIGHTNESS_BLUE_COEFFICIENT)) / AccessibilityConstants::BRIGHTNESS_DIVISOR;
+        return ColorAnalyzer::getBrightness($this);
     }
 
     public function isLight(): bool
     {
-        return $this->getBrightness() > AccessibilityConstants::BRIGHTNESS_THRESHOLD;
+        return ColorAnalyzer::isLight($this);
     }
 
     public function isDark(): bool
     {
-        return ! $this->isLight();
+        return ColorAnalyzer::isDark($this);
     }
 
     public function getContrastRatio(ColorInterface $color): float
     {
-        $l1 = $this->getLuminance() + AccessibilityConstants::CONTRAST_LUMINANCE_OFFSET;
-        $l2 = $color->getLuminance() + AccessibilityConstants::CONTRAST_LUMINANCE_OFFSET;
-
-        return $l1 > $l2 ? $l1 / $l2 : $l2 / $l1;
+        return ColorAnalyzer::getContrastRatio($this, $color);
     }
 
     public function getLuminance(): float
     {
-        $rgb = [$this->red, $this->green, $this->blue];
-        $rgb = array_map(function ($value) {
-            $value = $value / ValidationConstants::MAX_RGB_VALUE;
-
-            return $value <= AccessibilityConstants::LUMINANCE_GAMMA_THRESHOLD
-                ? $value / AccessibilityConstants::LUMINANCE_GAMMA_DIVISOR
-                : pow(($value + AccessibilityConstants::LUMINANCE_GAMMA_OFFSET) / AccessibilityConstants::LUMINANCE_GAMMA_MULTIPLIER,
-                    AccessibilityConstants::LUMINANCE_GAMMA_POWER);
-        }, $rgb);
-
-        return $rgb[0] * AccessibilityConstants::LUMINANCE_RED_COEFFICIENT +
-               $rgb[1] * AccessibilityConstants::LUMINANCE_GREEN_COEFFICIENT +
-               $rgb[2] * AccessibilityConstants::LUMINANCE_BLUE_COEFFICIENT;
+        return ColorAnalyzer::getLuminance($this);
     }
 
     public function lighten(float $amount): self
     {
-        $hsl = $this->toHsl();
-        $hsl['l'] = min(100, $hsl['l'] + $amount * 100);
-
-        return self::fromHsl($hsl['h'], $hsl['s'], $hsl['l']);
+        return ColorManipulator::lighten($this, $amount);
     }
 
     public function darken(float $amount): self
     {
-        $hsl = $this->toHsl();
-        $hsl['l'] = max(0, $hsl['l'] - $amount * 100);
-
-        return self::fromHsl($hsl['h'], $hsl['s'], $hsl['l']);
+        return ColorManipulator::darken($this, $amount);
     }
 
     public function saturate(float $amount): self
     {
-        $hsl = $this->toHsl();
-        $hsl['s'] = min(100, $hsl['s'] + $amount * 100);
-
-        return self::fromHsl($hsl['h'], $hsl['s'], $hsl['l']);
+        return ColorManipulator::saturate($this, $amount);
     }
 
     public function desaturate(float $amount): self
     {
-        $hsl = $this->toHsl();
-        $hsl['s'] = max(0, $hsl['s'] - $amount * 100);
-
-        return self::fromHsl($hsl['h'], $hsl['s'], $hsl['l']);
+        return ColorManipulator::desaturate($this, $amount);
     }
 
     public function rotate(float $degrees): self
     {
-        $hsl = $this->toHsl();
-        $hsl['h'] = fmod(($hsl['h'] + $degrees + 360), 360);
-
-        return self::fromHsl($hsl['h'], $hsl['s'], $hsl['l']);
+        return ColorManipulator::rotate($this, $degrees);
     }
 
     public function withLightness(float $lightness): self
     {
-        $hsl = $this->toHsl();
-
-        return self::fromHsl($hsl['h'], $hsl['s'], $lightness * 100);
+        return ColorManipulator::withLightness($this, $lightness);
     }
 
     /**

--- a/tests/Unit/ColorDelegationTest.php
+++ b/tests/Unit/ColorDelegationTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+use Farzai\ColorPalette\Color;
+use Farzai\ColorPalette\ColorAnalyzer;
+use Farzai\ColorPalette\ColorManipulator;
+
+/**
+ * Color's analysis/manipulation methods must delegate to the single-source
+ * services rather than re-implementing the formulas. These tests lock that
+ * contract so the implementations can never silently diverge again.
+ */
+describe('Color delegates analysis to ColorAnalyzer', function () {
+    $samples = [[0, 0, 0], [255, 255, 255], [18, 52, 86], [200, 100, 50], [120, 200, 60]];
+
+    foreach ($samples as $rgb) {
+        [$r, $g, $b] = $rgb;
+
+        test("analysis methods match ColorAnalyzer for rgb({$r},{$g},{$b})", function () use ($r, $g, $b) {
+            $color = new Color($r, $g, $b);
+
+            expect($color->getBrightness())->toBe(ColorAnalyzer::getBrightness($color));
+            expect($color->getLuminance())->toBe(ColorAnalyzer::getLuminance($color));
+            expect($color->isLight())->toBe(ColorAnalyzer::isLight($color));
+            expect($color->isDark())->toBe(ColorAnalyzer::isDark($color));
+
+            $other = new Color(255, 255, 255);
+            expect($color->getContrastRatio($other))->toBe(ColorAnalyzer::getContrastRatio($color, $other));
+        });
+    }
+});
+
+describe('Color delegates manipulation to ColorManipulator', function () {
+    $samples = [[200, 100, 50], [18, 52, 86], [120, 200, 60]];
+
+    foreach ($samples as $rgb) {
+        [$r, $g, $b] = $rgb;
+
+        test("manipulation methods match ColorManipulator for rgb({$r},{$g},{$b})", function () use ($r, $g, $b) {
+            $color = new Color($r, $g, $b);
+
+            expect($color->lighten(0.2)->toHex())->toBe(ColorManipulator::lighten($color, 0.2)->toHex());
+            expect($color->darken(0.2)->toHex())->toBe(ColorManipulator::darken($color, 0.2)->toHex());
+            expect($color->saturate(0.2)->toHex())->toBe(ColorManipulator::saturate($color, 0.2)->toHex());
+            expect($color->desaturate(0.2)->toHex())->toBe(ColorManipulator::desaturate($color, 0.2)->toHex());
+            expect($color->rotate(45)->toHex())->toBe(ColorManipulator::rotate($color, 45)->toHex());
+            expect($color->withLightness(0.7)->toHex())->toBe(ColorManipulator::withLightness($color, 0.7)->toHex());
+        });
+    }
+});


### PR DESCRIPTION
Part of the multi-PR review pass. **Pure refactor — no API or behaviour change.**

## Problem
The same formulas lived in two places each:
- `getLuminance` / `getContrastRatio` / `getBrightness` / `isLight` / `isDark` — duplicated verbatim between `Color` and `ColorAnalyzer`
- `lighten` / `darken` / `saturate` / `desaturate` / `rotate` / `withLightness` — duplicated between `Color` and `ColorManipulator`

Two copies of the WCAG luminance/contrast and HSL-manipulation math can silently diverge and double the test burden.

## Fix
`Color` now **delegates** to `ColorAnalyzer` / `ColorManipulator` — mirroring how it already delegated conversions to `ColorSpaceConverter`. Each formula now has exactly one home. Public method signatures are unchanged. `ColorManipulator`'s implementations were confirmed byte-for-byte equivalent to `Color`'s before delegating.

Also: RGB components are now `readonly`, making the value object's immutability explicit and enforced.

## Tests
- New `tests/Unit/ColorDelegationTest.php` locks the contract: `Color` results equal the service results across sample colors.
- Existing `ColorTest` / `ColorAnalyzerTest` / `ColorManipulatorTest` act as the regression net.

Full suite: **956 passed, 39 skipped**. Pint clean.

## Deferred (intentionally not here)
- `mt_srand()` global-RNG isolation in `AbstractColorExtractor` — fixing it changes extraction output, which is a stability concern for a published package; needs its own deliberate change.