### PR TITLE
refactor(strategies): centralize scheme resolution in a StrategyRegistry

### DIFF
--- a/src/ColorPalette.php
+++ b/src/ColorPalette.php
@@ -88,24 +88,10 @@ class ColorPalette implements ArrayAccess, ColorPaletteInterface, Countable, Ite
      */
     public static function fromColor(ColorInterface $color, string $scheme = 'monochromatic', array $options = []): self
     {
-        $generator = new PaletteGenerator($color);
-
-        $count = isset($options['count']) && is_int($options['count']) ? $options['count'] : 5;
-
-        return match ($scheme) {
-            'monochromatic' => $generator->monochromatic($count),
-            'complementary' => $generator->complementary(),
-            'analogous' => $generator->analogous(),
-            'triadic' => $generator->triadic(),
-            'tetradic' => $generator->tetradic(),
-            'split-complementary', 'splitComplementary' => $generator->splitComplementary(),
-            'shades' => $generator->shades($count),
-            'tints' => $generator->tints($count),
-            'pastel' => $generator->pastel(),
-            'vibrant' => $generator->vibrant(),
-            'website-theme', 'websiteTheme' => $generator->websiteTheme(),
-            default => throw new \InvalidArgumentException("Unknown scheme: {$scheme}"),
-        };
+        // Strategies read their own options (e.g. 'count') via getCountOption(),
+        // so the scheme name resolves through the shared registry and generates
+        // directly — no per-scheme dispatch to maintain here.
+        return StrategyRegistry::resolve($scheme)->generate($color, $options);
     }
 
     /**

--- a/src/ColorPaletteBuilder.php
+++ b/src/ColorPaletteBuilder.php
@@ -239,19 +239,6 @@ class ColorPaletteBuilder
      */
     private function resolveStrategy(string $name): PaletteGenerationStrategyInterface
     {
-        return match (strtolower($name)) {
-            'monochromatic' => new Strategies\MonochromaticStrategy,
-            'complementary' => new Strategies\ComplementaryStrategy,
-            'analogous' => new Strategies\AnalogousStrategy,
-            'triadic' => new Strategies\TriadicStrategy,
-            'tetradic' => new Strategies\TetradicStrategy,
-            'split-complementary', 'splitcomplementary' => new Strategies\SplitComplementaryStrategy,
-            'shades' => new Strategies\ShadesStrategy,
-            'tints' => new Strategies\TintsStrategy,
-            'pastel' => new Strategies\PastelStrategy,
-            'vibrant' => new Strategies\VibrantStrategy,
-            'website-theme', 'websitetheme' => new Strategies\WebsiteThemeStrategy,
-            default => throw new \InvalidArgumentException("Unknown color scheme: {$name}"),
-        };
+        return StrategyRegistry::resolve($name);
     }
 }

--- a/src/StrategyRegistry.php
+++ b/src/StrategyRegistry.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Farzai\ColorPalette;
+
+use Farzai\ColorPalette\Contracts\PaletteGenerationStrategyInterface;
+use InvalidArgumentException;
+
+/**
+ * Central registry mapping scheme names to palette-generation strategies
+ *
+ * Previously the name -> strategy mapping was duplicated across
+ * ColorPalette::fromColor() and ColorPaletteBuilder::resolveStrategy(), with
+ * divergent alias spellings (e.g. "splitComplementary" vs "splitcomplementary").
+ * Both now resolve through this single registry, so adding or renaming a scheme
+ * is a one-line change and the accepted aliases are consistent everywhere.
+ */
+class StrategyRegistry
+{
+    /**
+     * Canonical (normalized) scheme name => strategy class.
+     *
+     * @var array<string, class-string<PaletteGenerationStrategyInterface>>
+     */
+    private const STRATEGIES = [
+        'monochromatic' => Strategies\MonochromaticStrategy::class,
+        'complementary' => Strategies\ComplementaryStrategy::class,
+        'analogous' => Strategies\AnalogousStrategy::class,
+        'triadic' => Strategies\TriadicStrategy::class,
+        'tetradic' => Strategies\TetradicStrategy::class,
+        'splitcomplementary' => Strategies\SplitComplementaryStrategy::class,
+        'shades' => Strategies\ShadesStrategy::class,
+        'tints' => Strategies\TintsStrategy::class,
+        'pastel' => Strategies\PastelStrategy::class,
+        'vibrant' => Strategies\VibrantStrategy::class,
+        'websitetheme' => Strategies\WebsiteThemeStrategy::class,
+    ];
+
+    /**
+     * Resolve a scheme name (any supported spelling) to a strategy instance
+     *
+     * @throws InvalidArgumentException If the scheme name is not registered
+     */
+    public static function resolve(string $name): PaletteGenerationStrategyInterface
+    {
+        $key = self::normalize($name);
+
+        if (! isset(self::STRATEGIES[$key])) {
+            throw new InvalidArgumentException("Unknown color scheme: {$name}");
+        }
+
+        $class = self::STRATEGIES[$key];
+
+        return new $class;
+    }
+
+    /**
+     * Whether a scheme name (any supported spelling) is registered
+     */
+    public static function has(string $name): bool
+    {
+        return isset(self::STRATEGIES[self::normalize($name)]);
+    }
+
+    /**
+     * List the canonical scheme names
+     *
+     * @return array<int, string>
+     */
+    public static function names(): array
+    {
+        return array_keys(self::STRATEGIES);
+    }
+
+    /**
+     * Normalize a scheme name so spelling variants map to the same key
+     * (case-insensitive; '-', '_' and spaces are ignored).
+     */
+    private static function normalize(string $name): string
+    {
+        return str_replace(['-', '_', ' '], '', strtolower($name));
+    }
+}

--- a/tests/Unit/StrategyRegistryTest.php
+++ b/tests/Unit/StrategyRegistryTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+use Farzai\ColorPalette\Color;
+use Farzai\ColorPalette\ColorPalette;
+use Farzai\ColorPalette\Contracts\PaletteGenerationStrategyInterface;
+use Farzai\ColorPalette\Strategies\SplitComplementaryStrategy;
+use Farzai\ColorPalette\Strategies\WebsiteThemeStrategy;
+use Farzai\ColorPalette\StrategyRegistry;
+
+describe('StrategyRegistry', function () {
+    test('it resolves every canonical scheme name to a strategy', function () {
+        foreach (StrategyRegistry::names() as $name) {
+            expect(StrategyRegistry::resolve($name))
+                ->toBeInstanceOf(PaletteGenerationStrategyInterface::class);
+        }
+    });
+
+    test('it treats spelling variants as the same scheme', function () {
+        foreach (['split-complementary', 'splitComplementary', 'splitcomplementary', 'SPLIT_COMPLEMENTARY'] as $alias) {
+            expect(StrategyRegistry::resolve($alias))->toBeInstanceOf(SplitComplementaryStrategy::class);
+        }
+
+        foreach (['website-theme', 'websiteTheme', 'websitetheme'] as $alias) {
+            expect(StrategyRegistry::resolve($alias))->toBeInstanceOf(WebsiteThemeStrategy::class);
+        }
+    });
+
+    test('has() reports membership regardless of spelling', function () {
+        expect(StrategyRegistry::has('splitComplementary'))->toBeTrue();
+        expect(StrategyRegistry::has('TRIADIC'))->toBeTrue();
+        expect(StrategyRegistry::has('does-not-exist'))->toBeFalse();
+    });
+
+    test('it throws a clear error for unknown schemes', function () {
+        expect(fn () => StrategyRegistry::resolve('nope'))
+            ->toThrow(InvalidArgumentException::class, 'Unknown color scheme: nope');
+    });
+
+    test('ColorPalette::fromColor now accepts the camelCase alias the registry unified', function () {
+        $palette = ColorPalette::fromColor(new Color(52, 152, 219), 'splitcomplementary');
+
+        expect($palette)->toBeInstanceOf(ColorPalette::class);
+        expect($palette->count())->toBeGreaterThan(0);
+    });
+});


### PR DESCRIPTION
Part of the multi-PR review pass. **BC-safe** (accepted scheme names are now a superset).

## Problem
The scheme-name → strategy map was duplicated in `ColorPalette::fromColor()` and `ColorPaletteBuilder::resolveStrategy()`, and the aliases had **drifted**: `fromColor` accepted `splitComplementary` but not `splitcomplementary`; the builder (via `strtolower`) accepted the reverse. Adding a scheme meant editing two `match` blocks.

## Fix
New `StrategyRegistry` is the single source for `name → strategy`:
- `resolve()`, `has()`, `names()`
- spelling-insensitive normalization (case + `-`/`_`/space ignored), so `split-complementary`, `splitComplementary`, `splitcomplementary` all map to the same strategy everywhere.

`ColorPaletteBuilder::resolveStrategy()` and `ColorPalette::fromColor()` both delegate to it. `fromColor()` now generates directly from the resolved strategy (strategies already read `count` from options), dropping its bespoke dispatch.

## BC
All previously-accepted names still resolve (now a superset). The builder's `Unknown color scheme: <name>` message is preserved; `fromColor` still throws `InvalidArgumentException` on unknown schemes.

## Tests
- New `tests/Unit/StrategyRegistryTest.php` (resolution, alias unification, `has`, unknown-throws, `fromColor` alias).
- Existing `ColorPaletteTest` / `ColorPaletteBuilderTest` are the regression net.

Full suite: **961 passed, 39 skipped**. Pint clean.