### PR TITLE
docs(examples): fix color-space ranges, doc drift, and SSRF-safe demo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ This section guides you through submitting a bug report for Color Palette PHP. F
 
 **Before Submitting A Bug Report**
 - Check the documentation for a list of common questions and problems.
-- Ensure the bug is not already reported by searching on GitHub under [Issues](https://github.com/farzai/color-palette/issues).
+- Ensure the bug is not already reported by searching on GitHub under [Issues](https://github.com/parsilver/color-palette-php/issues).
 - If you're unable to find an open issue addressing the problem, open a new one.
 
 **How Do I Submit A (Good) Bug Report?**
@@ -62,7 +62,7 @@ Enhancement suggestions are tracked as GitHub issues. Create an issue and provid
 
 1. Clone your fork of the repository
 ```bash
-git clone https://github.com/<your-username>/color-palette.git
+git clone https://github.com/<your-username>/color-palette-php.git
 ```
 
 2. Install dependencies

--- a/README.md
+++ b/README.md
@@ -624,7 +624,6 @@ Only these MIME types are accepted:
 - `image/webp`
 - `image/bmp`
 - `image/tiff`
-- `image/svg+xml`
 
 #### HTTP Client Configuration
 
@@ -712,7 +711,7 @@ composer test
 Run tests with coverage:
 
 ```bash
-composer test:coverage
+composer test-coverage
 ```
 
 ## Contributing

--- a/example/01-basic-colors.php
+++ b/example/01-basic-colors.php
@@ -32,8 +32,8 @@ function displayColor($label, Color $color)
         sprintf('(%d, %d, %d)', $color->getRed(), $color->getGreen(), $color->getBlue()),
         sprintf('(%d°, %d%%, %d%%)',
             (int) $color->toHsl()['h'],
-            (int) ($color->toHsl()['s'] * 100),
-            (int) ($color->toHsl()['l'] * 100)
+            (int) $color->toHsl()['s'],
+            (int) $color->toHsl()['l']
         )
     );
 }
@@ -56,16 +56,16 @@ displayColor('From Hex', $red);
 $green = Color::fromRgb([0, 255, 0]);
 displayColor('From RGB', $green);
 
-// From HSL (Hue, Saturation, Lightness)
-$blue = Color::fromHsl(240, 1.0, 0.5);  // Hue: 240°, Sat: 100%, Light: 50%
+// From HSL (Hue, Saturation, Lightness) - saturation/lightness are percentages (0-100)
+$blue = Color::fromHsl(240, 100, 50);  // Hue: 240°, Sat: 100%, Light: 50%
 displayColor('From HSL', $blue);
 
-// From HSV (Hue, Saturation, Value)
-$yellow = Color::fromHsv(60, 1.0, 1.0);  // Hue: 60°, Sat: 100%, Value: 100%
+// From HSV (Hue, Saturation, Value) - saturation/value are percentages (0-100)
+$yellow = Color::fromHsv(60, 100, 100);  // Hue: 60°, Sat: 100%, Value: 100%
 displayColor('From HSV', $yellow);
 
-// From CMYK (Cyan, Magenta, Yellow, Black) - used in printing
-$cyan = Color::fromCmyk(1.0, 0.0, 0.0, 0.0);  // 100% cyan
+// From CMYK (Cyan, Magenta, Yellow, Black) - all components are percentages (0-100)
+$cyan = Color::fromCmyk(100, 0, 0, 0);  // 100% cyan
 displayColor('From CMYK', $cyan);
 
 // From LAB (perceptually uniform color space)
@@ -88,16 +88,16 @@ $rgb = $color->toRgb();
 echo sprintf("RGB:    rgb(%d, %d, %d)\n", $rgb['r'], $rgb['g'], $rgb['b']);
 
 $hsl = $color->toHsl();
-echo sprintf("HSL:    hsl(%d°, %.1f%%, %.1f%%)\n",
-    (int) $hsl['h'], $hsl['s'] * 100, $hsl['l'] * 100);
+echo sprintf("HSL:    hsl(%d°, %d%%, %d%%)\n",
+    (int) $hsl['h'], $hsl['s'], $hsl['l']);
 
 $hsv = $color->toHsv();
-echo sprintf("HSV:    hsv(%d°, %.1f%%, %.1f%%)\n",
-    (int) $hsv['h'], $hsv['s'] * 100, $hsv['v'] * 100);
+echo sprintf("HSV:    hsv(%d°, %d%%, %d%%)\n",
+    (int) $hsv['h'], $hsv['s'], $hsv['v']);
 
 $cmyk = $color->toCmyk();
-echo sprintf("CMYK:   cmyk(%.1f%%, %.1f%%, %.1f%%, %.1f%%)\n",
-    $cmyk['c'] * 100, $cmyk['m'] * 100, $cmyk['y'] * 100, $cmyk['k'] * 100);
+echo sprintf("CMYK:   cmyk(%d%%, %d%%, %d%%, %d%%)\n",
+    $cmyk['c'], $cmyk['m'], $cmyk['y'], $cmyk['k']);
 
 $lab = $color->toLab();
 echo sprintf("LAB:    lab(%.1f, %.1f, %.1f)\n", $lab['l'], $lab['a'], $lab['b']);

--- a/example/web-ui/App.jsx
+++ b/example/web-ui/App.jsx
@@ -864,7 +864,7 @@ function ColorManipulator() {
                                     <div className="space-y-1 text-xs">
                                         <p className="font-mono"><span className="text-muted-foreground">HEX:</span> {result.original.hex}</p>
                                         <p className="font-mono"><span className="text-muted-foreground">RGB:</span> {result.original.rgb.r}, {result.original.rgb.g}, {result.original.rgb.b}</p>
-                                        <p className="font-mono"><span className="text-muted-foreground">HSL:</span> {Math.round(result.original.hsl.h)}°, {Math.round(result.original.hsl.s * 100)}%, {Math.round(result.original.hsl.l * 100)}%</p>
+                                        <p className="font-mono"><span className="text-muted-foreground">HSL:</span> {Math.round(result.original.hsl.h)}°, {Math.round(result.original.hsl.s)}%, {Math.round(result.original.hsl.l)}%</p>
                                     </div>
                                 </div>
 
@@ -879,7 +879,7 @@ function ColorManipulator() {
                                     <div className="space-y-1 text-xs">
                                         <p className="font-mono"><span className="text-muted-foreground">HEX:</span> {result.result.hex}</p>
                                         <p className="font-mono"><span className="text-muted-foreground">RGB:</span> {result.result.rgb.r}, {result.result.rgb.g}, {result.result.rgb.b}</p>
-                                        <p className="font-mono"><span className="text-muted-foreground">HSL:</span> {Math.round(result.result.hsl.h)}°, {Math.round(result.result.hsl.s * 100)}%, {Math.round(result.result.hsl.l * 100)}%</p>
+                                        <p className="font-mono"><span className="text-muted-foreground">HSL:</span> {Math.round(result.result.hsl.h)}°, {Math.round(result.result.hsl.s)}%, {Math.round(result.result.hsl.l)}%</p>
                                     </div>
                                 </div>
                             </div>

--- a/example/web-ui/api.php
+++ b/example/web-ui/api.php
@@ -3,7 +3,9 @@
 require_once __DIR__.'/../../vendor/autoload.php';
 
 use Farzai\ColorPalette\Color;
+use Farzai\ColorPalette\ColorExtractorFactory;
 use Farzai\ColorPalette\ColorPalette;
+use Farzai\ColorPalette\ImageLoaderFactory;
 
 // Enable CORS for local development
 header('Access-Control-Allow-Origin: *');
@@ -90,16 +92,13 @@ function handleExtract()
         if (! empty($_POST['url'])) {
             $url = $_POST['url'];
 
-            // Download the image to a temporary file
-            $imageData = @file_get_contents($url);
-            if ($imageData === false) {
-                throw new Exception('Failed to download image from URL');
-            }
-
-            // Create a temporary file
-            $tempFile = tempnam(sys_get_temp_dir(), 'color_palette_');
-            file_put_contents($tempFile, $imageData);
-            $imagePath = $tempFile;
+            // Load via the library's SSRF-protected loader instead of a raw
+            // file_get_contents(): it validates the scheme, blocks private/reserved
+            // IPs (re-checking every redirect hop), and enforces the byte-size and
+            // decoded-dimension limits before the image is ever decoded.
+            $image = (new ImageLoaderFactory)->create()->load($url);
+            $palette = (new ColorExtractorFactory)->make('gd')->extract($image, $count);
+            assert($palette instanceof ColorPalette);
 
         } elseif (isset($_FILES['image'])) {
             // Handle uploaded file
@@ -130,8 +129,11 @@ function handleExtract()
             throw new Exception('No image provided');
         }
 
-        // Extract colors from image
-        $palette = ColorPalette::fromImage($imagePath, $count);
+        // Extract colors from the uploaded file (the URL branch above already
+        // produced $palette through the SSRF-protected loader).
+        if (! isset($palette)) {
+            $palette = ColorPalette::fromImage($imagePath, $count);
+        }
 
         // Get color information
         $colors = [];


### PR DESCRIPTION
Follow-up to the code-review fixes (PR #31–#35), addressing the documentation/examples findings.

## Changes
- **example/01-basic-colors.php** — pass `0-100` to `fromHsl/fromHsv/fromCmyk` (was `0.0-1.0`, rendering near-black/white) and stop multiplying already-0-100 HSL/HSV/CMYK by 100.
- **example/web-ui/App.jsx** — stop multiplying the API's 0-100 HSL s/l by 100 (was showing up to 10000%).
- **example/web-ui/api.php** — load user URLs through `ImageLoaderFactory` (SSRF/size/dimension guards) instead of raw `file_get_contents()`.
- **README.md** — drop `image/svg+xml` from the accepted-MIME list; fix `composer test:coverage` → `test-coverage`.
- **CONTRIBUTING.md** — fix repo slug `color-palette` → `color-palette-php`.

## Verification
- `composer test` → 961 passed, 39 skipped
- `composer format` (Pint) → clean
- `php -l` on all `example/*.php` → clean

Note: the `CODE_OF_CONDUCT.md` dead link in CONTRIBUTORS.md is intentionally left for a separate decision.