### PR TITLE
ci: wire up PHPStan static analysis and verify Mockery expectations

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -1,0 +1,41 @@
+name: Static Analysis
+
+on:
+  push:
+    paths:
+      - "**.php"
+      - "phpstan.neon.dist"
+      - "composer.json"
+      - "composer.lock"
+      - ".github/workflows/static-analysis.yml"
+  pull_request:
+    paths:
+      - "**.php"
+      - "phpstan.neon.dist"
+      - "composer.json"
+      - "composer.lock"
+      - ".github/workflows/static-analysis.yml"
+
+jobs:
+  phpstan:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    name: PHPStan
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.3
+          extensions: dom, curl, libxml, mbstring, gd, imagick, fileinfo
+          coverage: none
+
+      - name: Install dependencies
+        run: composer update --prefer-dist --no-interaction
+
+      - name: Run PHPStan
+        run: composer analyse

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,4 @@
+parameters:
+    level: 6
+    paths:
+        - src

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,1 +1,10 @@
 <?php
+
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+
+/*
+ * Bind Mockery's PHPUnit integration to every test that uses mocks so that
+ * mock expectations (e.g. ->once(), ->with(...)) are verified and Mockery is
+ * closed after each test. Without this, unmet expectations pass silently.
+ */
+uses(MockeryPHPUnitIntegration::class)->in('Unit', 'Integration');


### PR DESCRIPTION
Closes the tooling-vs-claims gap from the review: `composer analyse` is configured (phpstan was a dep with no config), CI now runs it, and Mockery expectations are actually verified.

## Changes
- **phpstan.neon.dist** — level 6 over `src/`, clean with **no baseline/ignores**. Levels 7-9 only flag the `method_exists()`-based Imagick resource calls that `ArchTest` mandates over `instanceof`, so 6 is the honest ceiling.
- **.github/workflows/static-analysis.yml** — runs `composer analyse` on push/PR.
- **tests/Pest.php** — `uses(MockeryPHPUnitIntegration::class)` so `->once()`/`->with()` expectations are verified (was silently unverified).

## Verification
- `composer analyse` → No errors (51 files, level 6)
- `composer test` → 961 passed, 39 skipped
- `composer format` (Pint) → clean