### PR TITLE
fix(images): guard ImagickImage destructor against clear() failures

### DIFF
--- a/src/Images/ImagickImage.php
+++ b/src/Images/ImagickImage.php
@@ -30,6 +30,12 @@ class ImagickImage implements ImageInterface
 
     public function __destruct()
     {
-        $this->resource->clear();
+        try {
+            $this->resource->clear();
+        } catch (\Throwable) {
+            // Imagick::clear() can throw if the resource is already destroyed or
+            // invalid; a destructor must never let an exception escape (it would
+            // become a fatal error during object destruction / script shutdown).
+        }
     }
 }

--- a/tests/Unit/Images/ImagickImageTest.php
+++ b/tests/Unit/Images/ImagickImageTest.php
@@ -9,6 +9,22 @@ beforeEach(function () {
     }
 });
 
+describe('ImagickImage - Resource Cleanup Safety', function () {
+    test('its destructor swallows Imagick::clear() failures', function () {
+        // A destructor must never let an exception escape (it would become a
+        // fatal error during shutdown). Force clear() to throw and assert the
+        // object can be destroyed without the exception propagating.
+        $resource = Mockery::mock(Imagick::class);
+        $resource->shouldReceive('clear')->andThrow(new ImagickException('clear failed'));
+
+        $image = new ImagickImage($resource);
+
+        unset($image); // triggers __destruct -> clear() throws -> must be swallowed
+
+        expect(true)->toBeTrue();
+    });
+});
+
 describe('ImagickImage - Basic Functionality', function () {
     test('it can be constructed with Imagick resource', function () {
         $imagick = new Imagick;


### PR DESCRIPTION
Robustness fix from the review.

## Change
- **ImagickImage::__destruct()** wrapped `$this->resource->clear()` in try/catch. `Imagick::clear()` can throw on an already-destroyed/invalid resource, and an exception escaping a destructor during shutdown becomes an uncatchable fatal error.
- Added a test (runs where the `imagick` extension is available) that forces `clear()` to throw and asserts the destructor swallows it.

`Color` r/g/b are already `readonly` (done in an earlier PR), so no change there.

## Verification
- `composer analyse` → No errors (level 6)
- `composer test` → 961 passed, 40 skipped (the new imagick test skips locally, runs in CI)
- `composer format` (Pint) → clean