### PR TITLE
build!: drop PHP 8.1 support, require ^8.2

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest]
-        php: [8.5, 8.4, 8.3, 8.2, 8.1]
+        php: [8.5, 8.4, 8.3, 8.2]
         stability: [prefer-lowest, prefer-stable]
 
     name: P${{ matrix.php }} - ${{ matrix.stability }} - ${{ matrix.os }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,7 +78,7 @@ composer test
 ### Coding Standards
 
 - Follow PSR-12 coding standards
-- Use PHP 8.1+ features appropriately
+- Use PHP 8.2+ features appropriately
 - Add PHPDoc blocks for all classes and methods
 - Write tests for new features
 - Maintain high test coverage
@@ -120,7 +120,7 @@ composer test-coverage
 
 ### PHP Version Support
 
-- Code must be compatible with PHP 8.1 and above
+- Code must be compatible with PHP 8.2 and above
 - Use type declarations where possible
 - Leverage modern PHP features when appropriate
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ A powerful PHP library for extracting color palettes from images and generating 
 
 ## Requirements
 
-- PHP 8.1 or higher
+- PHP 8.2 or higher
 - GD extension **OR** ImageMagick extension (at least one is required)
 - Composer
 

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         }
     ],
     "require": {
-        "php": "^8.1",
+        "php": "^8.2",
         "nyholm/psr7": "^1.8",
         "psr/http-client": "^1.0",
         "psr/http-factory": "^1.1",


### PR DESCRIPTION
Fixes the long-standing red **Tests** CI cell (failing since PR #31, unrelated to library code).

## Root cause
`paratest 7.x` (transitive dep of `pestphp/pest ^2`) requires PHP **>= 8.2**, so `composer update` cannot resolve on PHP 8.1 — the `P8.1 - prefer-lowest` matrix job errored at *Install dependencies*, and `fail-fast` cancelled the rest. PHP 8.1 also reached security EOL on 2025-12-31.

## Changes
- **composer.json** — `"php": "^8.1"` → `"^8.2"`.
- **.github/workflows/run-tests.yml** — drop `8.1` from the matrix (now 8.2–8.5).
- **README.md / CONTRIBUTING.md** — document PHP 8.2 as the minimum.

## Verification (local, PHP 8.5)
- `composer test` → 961 passed, 40 skipped
- `composer analyse` → No errors (level 6)
- `composer format` (Pint) → clean

**BREAKING CHANGE:** minimum PHP is now 8.2.