### PR TITLE
refactor(http)!: make the HTTP client optional (PSR-18 + discovery)

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ A powerful PHP library for extracting color palettes from images and generating 
 
 - PHP 8.2 or higher
 - GD extension **OR** ImageMagick extension (at least one is required)
+- A [PSR-18](https://www.php-fig.org/psr/psr-18/) HTTP client **only if you load images from URLs** (e.g. `symfony/http-client` or `guzzlehttp/guzzle`) — not needed for local files
 - Composer
 
 ## Installation
@@ -59,6 +60,21 @@ Install the package via composer:
 ```bash
 composer require farzai/color-palette
 ```
+
+### Loading images from URLs (optional)
+
+Extracting colors from **local files has no HTTP dependencies**. To load images from
+**remote URLs**, also install any [PSR-18](https://www.php-fig.org/psr/psr-18/) HTTP
+client — it is auto-discovered, no wiring required:
+
+```bash
+composer require symfony/http-client   # recommended
+# or: composer require guzzlehttp/guzzle
+```
+
+`symfony/http-client` is recommended because the loader configures it to not follow
+redirects, so every redirect hop is re-validated against the SSRF rules. You can also
+pass your own PSR-18 client / PSR-17 factory to `ImageLoaderFactory` or `ImageLoader`.
 
 ## Quick Start
 

--- a/composer.json
+++ b/composer.json
@@ -27,18 +27,25 @@
     ],
     "require": {
         "php": "^8.2",
-        "nyholm/psr7": "^1.8",
+        "php-http/discovery": "^1.20",
         "psr/http-client": "^1.0",
         "psr/http-factory": "^1.1",
         "psr/http-message": "^2.0",
-        "symfony/http-client": "^6.4|^7.2"
+        "psr/log": "^1.1|^2.0|^3.0"
     },
     "require-dev": {
         "laravel/pint": "^1.0",
         "mockery/mockery": "^1.6",
+        "nyholm/psr7": "^1.8",
         "pestphp/pest": "^2.20|^3.7|^4.0",
         "phpstan/phpstan": "^2.0",
-        "spatie/ray": "^1.28"
+        "spatie/ray": "^1.28",
+        "symfony/http-client": "^6.4|^7.2"
+    },
+    "suggest": {
+        "symfony/http-client": "Recommended PSR-18 client for loading images from remote URLs; the factory configures it to not follow redirects for SSRF safety",
+        "guzzlehttp/guzzle": "Alternative PSR-18 client (auto-discovered) for loading images from remote URLs",
+        "nyholm/psr7": "Lightweight PSR-17 request factory, if your PSR-18 client does not provide one"
     },
     "autoload": {
         "psr-4": {
@@ -60,7 +67,8 @@
         "sort-packages": true,
         "allow-plugins": {
             "pestphp/pest-plugin": true,
-            "phpstan/extension-installer": true
+            "phpstan/extension-installer": true,
+            "php-http/discovery": true
         }
     },
     "minimum-stability": "dev",

--- a/src/ImageLoaderFactory.php
+++ b/src/ImageLoaderFactory.php
@@ -6,9 +6,11 @@ namespace Farzai\ColorPalette;
 
 use Farzai\ColorPalette\Config\HttpClientConfig;
 use Farzai\ColorPalette\Services\ExtensionChecker;
-use Nyholm\Psr7\Factory\Psr17Factory;
+use Http\Discovery\Psr17FactoryDiscovery;
+use Http\Discovery\Psr18ClientDiscovery;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
+use RuntimeException;
 use Symfony\Component\HttpClient\HttpClient;
 use Symfony\Component\HttpClient\Psr18Client;
 
@@ -25,13 +27,13 @@ class ImageLoaderFactory
     public function create(): ImageLoader
     {
         $httpConfig = $this->httpConfig ?? new HttpClientConfig;
-        $httpClient = $this->httpClient ?? $this->createDefaultHttpClient($httpConfig);
-        $psr17Factory = $this->requestFactory ?? new Psr17Factory;
+        $httpClient = $this->httpClient ?? $this->resolveHttpClient($httpConfig);
+        $requestFactory = $this->requestFactory ?? $this->resolveRequestFactory($httpClient);
         $extensionChecker = $this->extensionChecker ?? new ExtensionChecker;
 
         return new ImageLoader(
             $httpClient,
-            $psr17Factory,
+            $requestFactory,
             null, // imageFactory
             $extensionChecker,
             $this->preferredDriver,
@@ -40,24 +42,74 @@ class ImageLoaderFactory
     }
 
     /**
-     * Create a properly configured Symfony HttpClient
+     * Resolve a PSR-18 HTTP client to use for downloading remote images.
+     *
+     * The library does not depend on a concrete HTTP client. When Symfony's
+     * HttpClient is installed we build a securely-configured instance (redirects
+     * disabled at the transport layer so ImageLoader can follow + re-validate
+     * each hop against the SSRF rules); otherwise we discover any PSR-18 client
+     * the project provides. If none is available, URL loading is unsupported.
+     *
+     * @throws RuntimeException If no PSR-18 client can be resolved
      */
-    private function createDefaultHttpClient(HttpClientConfig $config): ClientInterface
+    private function resolveHttpClient(HttpClientConfig $config): ClientInterface
     {
-        $symfonyClient = HttpClient::create([
-            'timeout' => $config->getTimeoutSeconds(),
-            // Never auto-follow redirects at the transport layer: ImageLoader follows
-            // them itself and re-validates each hop against the SSRF rules. Letting the
-            // client follow internally would skip that check (the config's maxRedirects
-            // is the budget ImageLoader uses for validated following).
-            'max_redirects' => 0,
-            'verify_peer' => $config->shouldVerifySsl(),
-            'verify_host' => $config->shouldVerifySsl(),
-            'headers' => [
-                'User-Agent' => $config->getUserAgent(),
-            ],
-        ]);
+        if (class_exists(Psr18Client::class) && class_exists(HttpClient::class)) {
+            return new Psr18Client(HttpClient::create([
+                'timeout' => $config->getTimeoutSeconds(),
+                // Never auto-follow redirects at the transport layer: ImageLoader
+                // follows them itself and re-validates each hop against the SSRF
+                // rules. The config's maxRedirects is the budget it uses.
+                'max_redirects' => 0,
+                'verify_peer' => $config->shouldVerifySsl(),
+                'verify_host' => $config->shouldVerifySsl(),
+                'headers' => [
+                    'User-Agent' => $config->getUserAgent(),
+                ],
+            ]));
+        }
 
-        return new Psr18Client($symfonyClient);
+        if (class_exists(Psr18ClientDiscovery::class)) {
+            try {
+                return Psr18ClientDiscovery::find();
+            } catch (\Throwable) {
+                // Fall through to the explicit error below.
+            }
+        }
+
+        throw new RuntimeException(
+            'No PSR-18 HTTP client is available to load images from URLs. Install '
+            .'symfony/http-client (recommended) or any PSR-18 client, or pass your '
+            .'own client to ImageLoaderFactory / ImageLoader. Loading images from a '
+            .'local file path does not require an HTTP client.'
+        );
+    }
+
+    /**
+     * Resolve a PSR-17 request factory.
+     *
+     * Many PSR-18 clients (e.g. Symfony's Psr18Client) also implement PSR-17, so
+     * the client itself is reused when possible; otherwise a factory is discovered.
+     *
+     * @throws RuntimeException If no PSR-17 request factory can be resolved
+     */
+    private function resolveRequestFactory(ClientInterface $client): RequestFactoryInterface
+    {
+        if ($client instanceof RequestFactoryInterface) {
+            return $client;
+        }
+
+        if (class_exists(Psr17FactoryDiscovery::class)) {
+            try {
+                return Psr17FactoryDiscovery::findRequestFactory();
+            } catch (\Throwable) {
+                // Fall through to the explicit error below.
+            }
+        }
+
+        throw new RuntimeException(
+            'No PSR-17 request factory is available. Install a PSR-17 implementation '
+            .'(e.g. nyholm/psr7) or pass one to ImageLoaderFactory / ImageLoader.'
+        );
     }
 }

--- a/tests/Unit/ImageLoaderFactoryTest.php
+++ b/tests/Unit/ImageLoaderFactoryTest.php
@@ -3,6 +3,10 @@
 use Farzai\ColorPalette\ImageLoader;
 use Farzai\ColorPalette\ImageLoaderFactory;
 use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamInterface;
 
 test('it can create image loader instance', function () {
     $factory = new ImageLoaderFactory;
@@ -25,4 +29,32 @@ test('it accepts custom http client via constructor', function () {
     $loader = $factory->create();
 
     expect($loader)->toBeInstanceOf(ImageLoader::class);
+});
+
+test('it reuses the http client as the request factory when it implements RequestFactoryInterface', function () {
+    // A client that doubles as a PSR-17 request factory (like Symfony's Psr18Client).
+    // When only such a client is injected, the loader must call createRequest() on
+    // the client itself — proving the factory reused it instead of building a
+    // separate PSR-17 factory (which is what lets us drop the hard nyholm dependency).
+    $client = Mockery::mock(ClientInterface::class, RequestFactoryInterface::class);
+    $request = Mockery::mock(RequestInterface::class);
+    $response = Mockery::mock(ResponseInterface::class);
+    $stream = Mockery::mock(StreamInterface::class);
+
+    $client->shouldReceive('createRequest')->once()
+        ->with('GET', 'https://example.com/image.jpg')->andReturn($request);
+    $request->shouldReceive('withHeader')->with('User-Agent', Mockery::any())->andReturnSelf();
+    $client->shouldReceive('sendRequest')->with($request)->andReturn($response);
+    $response->shouldReceive('getStatusCode')->andReturn(200);
+    $response->shouldReceive('hasHeader')->with('Content-Length')->andReturn(false);
+    $response->shouldReceive('hasHeader')->with('Content-Type')->andReturn(false);
+    $response->shouldReceive('getBody')->andReturn($stream);
+    $stream->shouldReceive('eof')->andReturn(false, true);
+    $stream->shouldReceive('read')->with(8192)->andReturn(file_get_contents(__DIR__.'/../../example/assets/sample.jpg'));
+
+    // Inject ONLY the client — no separate request factory.
+    $loader = (new ImageLoaderFactory($client))->create();
+    $image = $loader->load('https://example.com/image.jpg');
+
+    expect($image->getWidth())->toBeGreaterThan(0);
 });


### PR DESCRIPTION
Part of the 2.0 lightening pass. The library no longer bundles a concrete HTTP client.

## Why
`symfony/http-client` + `nyholm/psr7` were hard dependencies, so **10 of 11 prod packages** came from URL loading — even for users who only extract colors from local files.

## What
`ImageLoader` was already PSR-18/17 agnostic; only `ImageLoaderFactory` hard-coded Symfony. The factory now resolves the client/factory:
1. **Symfony if installed** → built with redirects disabled (so `ImageLoader` re-validates every hop against SSRF rules — preserves current protection);
2. **else auto-discover** any PSR-18 client / PSR-17 factory via `php-http/discovery` (a client that also implements PSR-17, like Symfony's `Psr18Client`, is reused as the request factory);
3. **else** throw a clear error explaining how to enable URL loading.

`symfony/http-client` + `nyholm/psr7` → `require-dev` + `suggest`; `php-http/discovery` + `psr/log` (was transitive via Symfony) → direct `require`.

## Impact (verified)
- Prod dependencies **11 → 5** (`composer install --no-dev`): only `php-http/discovery` + `psr/http-*` + `psr/log`; **no Symfony/Nyholm**.
- Local extraction works with **zero HTTP client** (smoke-tested: 5 colors from sample.jpg).
- TDD: added a test proving the factory reuses a client that implements `RequestFactoryInterface`.

## Verification
- `composer test` → 962 passed, 40 skipped
- `composer analyse` → No errors (level 6)
- `composer format` → clean

**BREAKING CHANGE:** URL loading now requires a PSR-18 client (install `symfony/http-client`/`guzzlehttp/guzzle` or inject one). Local files & color ops unaffected.