### PR TITLE
chore: 2.0 release prep — slimmer package, stable, RNG isolation, upgrade guide

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,15 +1,16 @@
 # Path-based git attributes
 # https://www.kernel.org/pub/software/scm/git/docs/gitattributes.html
 
-# Ignore all test and documentation with "export-ignore".
+# Exclude development and repo-only files from the distributed package
+# (export-ignore keeps `composer require` downloads small).
 /.github export-ignore
 /.gitattributes export-ignore
 /.gitignore export-ignore
-/phpunit.xml.dist export-ignore
-/psalm.xml.dist export-ignore
-/tests export-ignore
 /.editorconfig export-ignore
-/.php-cs-fixer.dist.php export-ignore
-/art export-ignore
-/docs export-ignore
+/CONTRIBUTING.md export-ignore
+/CONTRIBUTORS.md export-ignore
 /UPGRADING.md export-ignore
+/example export-ignore
+/phpstan.neon.dist export-ignore
+/phpunit.xml.dist export-ignore
+/tests export-ignore

--- a/README.md
+++ b/README.md
@@ -696,16 +696,21 @@ try {
 When accepting URLs from users:
 
 ```php
-// ✓ GOOD: Validate and handle errors
+use Farzai\ColorPalette\ColorExtractorFactory;
+use Farzai\ColorPalette\ImageLoaderFactory;
+
+// ✓ GOOD: load through the SSRF-protected loader and handle errors.
+// (ColorPalette::fromImage() is for local paths only — it does not fetch URLs.)
 try {
-    $palette = ColorPalette::fromImage($userUrl, count: 5);
+    $image = (new ImageLoaderFactory)->create()->load($userUrl);
+    $palette = (new ColorExtractorFactory)->make('gd')->extract($image, 5);
 } catch (SsrfException $e) {
     // Don't expose internal network structure in error messages
     throw new UserFacingException('Invalid URL provided');
 }
 
 // ✗ BAD: Don't blindly trust user input
-$palette = ColorPalette::fromImage($_GET['url']); // Dangerous!
+$image = (new ImageLoaderFactory)->create()->load($_GET['url']); // validate first!
 
 // ✓ GOOD: Add URL whitelist for extra security
 $allowedDomains = ['cdn.example.com', 'images.example.com'];

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -3,9 +3,15 @@
 ## Upgrading from 1.x to 2.0
 
 Version 2.0 focuses on a lighter dependency footprint and a higher minimum PHP
-version. Color extraction, conversion, manipulation, analysis, and palette
-generation are **unchanged** — the breaking changes are limited to the minimum
-PHP version and to loading images from remote URLs.
+version. The public API of color conversion, manipulation, analysis, and palette
+generation is **unchanged**; the breaking changes are limited to the minimum PHP
+version and to loading images from remote URLs.
+
+> **Note on extracted colors:** the k-means image extractor's centroid seeding
+> moved off PHP's global `mt_rand()` to a locally-seeded `\Random\Randomizer`
+> (so extraction no longer mutates your global RNG state). Results remain
+> deterministic and idempotent, but the exact colors extracted from a given
+> image with `count > 1` may differ slightly from 1.x.
 
 ### 1. PHP 8.2 is now required
 
@@ -52,7 +58,14 @@ $loader = (new ImageLoaderFactory(httpClient: $yourPsr18Client))->create();
 ```
 
 If you call `load()` with a URL and no PSR-18 client is available, a
-`RuntimeException` is thrown explaining how to install or inject one.
+`RuntimeException` is thrown explaining how to install or inject one. Loading a
+**local file path needs no HTTP client** and always works.
+
+**Direct constructors:** `ImageLoader` and `ImageLoaderFactory` no longer accept
+a PSR-17 `StreamFactoryInterface` / `$streamFactory` argument (it was unused). If
+you construct either directly, drop that argument and prefer the named arguments
+`httpClient:` / `requestFactory:` / `httpConfig:`. Both the client and request
+factory are now optional and default to `null`.
 
 ### 3. Removed `ImageConstants::HTTP_OK`
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,0 +1,61 @@
+# Upgrade Guide
+
+## Upgrading from 1.x to 2.0
+
+Version 2.0 focuses on a lighter dependency footprint and a higher minimum PHP
+version. Color extraction, conversion, manipulation, analysis, and palette
+generation are **unchanged** — the breaking changes are limited to the minimum
+PHP version and to loading images from remote URLs.
+
+### 1. PHP 8.2 is now required
+
+The minimum supported PHP version is now **8.2** (was 8.1). PHP 8.1 reached its
+end of security support on 2025-12-31.
+
+**What to do:** upgrade your runtime to PHP 8.2 or newer.
+
+### 2. The HTTP client is no longer bundled
+
+Previously `symfony/http-client` and `nyholm/psr7` were hard dependencies, so
+every install pulled the full Symfony HTTP stack — even when you only extracted
+colors from local files. They have been removed from the package's
+requirements.
+
+- **Local files and color operations** need no HTTP client and work out of the box.
+- **Loading images from a URL** now requires a [PSR-18](https://www.php-fig.org/psr/psr-18/)
+  HTTP client (and a PSR-17 factory) to be installed or injected. Any PSR-18
+  client is auto-discovered via `php-http/discovery`.
+
+**What to do — only if you load images from URLs:**
+
+```bash
+composer require symfony/http-client   # recommended
+# or: composer require guzzlehttp/guzzle
+```
+
+`symfony/http-client` is recommended because the factory configures it to not
+follow redirects, so every redirect hop is re-validated against the SSRF rules.
+
+Nothing else changes — this keeps working once a client is present:
+
+```php
+use Farzai\ColorPalette\ImageLoaderFactory;
+
+$loader = (new ImageLoaderFactory)->create();
+$image = $loader->load('https://example.com/image.jpg');
+```
+
+You can also inject your own client/factory instead of relying on discovery:
+
+```php
+$loader = (new ImageLoaderFactory(httpClient: $yourPsr18Client))->create();
+```
+
+If you call `load()` with a URL and no PSR-18 client is available, a
+`RuntimeException` is thrown explaining how to install or inject one.
+
+### 3. Removed `ImageConstants::HTTP_OK`
+
+The unused public constant `Farzai\ColorPalette\Constants\ImageConstants::HTTP_OK`
+was removed. It was never referenced by the library. If you referenced it, use
+the literal `200` instead.

--- a/composer.json
+++ b/composer.json
@@ -71,6 +71,6 @@
             "php-http/discovery": true
         }
     },
-    "minimum-stability": "dev",
+    "minimum-stability": "stable",
     "prefer-stable": true
 }

--- a/src/AbstractColorExtractor.php
+++ b/src/AbstractColorExtractor.php
@@ -10,6 +10,8 @@ use Farzai\ColorPalette\Contracts\ColorPaletteInterface;
 use Farzai\ColorPalette\Contracts\ImageInterface;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
+use Random\Engine\Mt19937;
+use Random\Randomizer;
 
 /**
  * Abstract base class for color extractors
@@ -272,12 +274,13 @@ abstract class AbstractColorExtractor implements ColorExtractorInterface
     {
         $centroids = [];
 
-        // Seed the random number generator for deterministic results
-        mt_srand($this->seed);
+        // Locally-seeded randomizer: deterministic, reproducible centroid selection
+        // without mutating PHP's global RNG state (mt_srand) as a side effect.
+        $randomizer = new Randomizer(new Mt19937($this->seed));
 
-        // Choose first centroid using seeded random
+        // Choose first centroid using the seeded randomizer
         $colorKeys = array_keys($colors);
-        $firstIndex = $colorKeys[mt_rand(0, count($colorKeys) - 1)];
+        $firstIndex = $colorKeys[$randomizer->getInt(0, count($colorKeys) - 1)];
         $centroids[] = [
             'r' => $colors[$firstIndex]['r'],
             'g' => $colors[$firstIndex]['g'],
@@ -298,7 +301,7 @@ abstract class AbstractColorExtractor implements ColorExtractorInterface
 
             // Choose next centroid with probability proportional to distance (seeded)
             $sum = array_sum($distances);
-            $target = (mt_rand() / mt_getrandmax()) * $sum;
+            $target = $randomizer->getInt(0, PHP_INT_MAX) / PHP_INT_MAX * $sum;
             $currentSum = 0;
             foreach ($colors as $index => $color) {
                 $currentSum += $distances[$index];

--- a/src/ImageLoader.php
+++ b/src/ImageLoader.php
@@ -15,6 +15,7 @@ use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;
+use RuntimeException;
 
 class ImageLoader
 {
@@ -30,8 +31,8 @@ class ImageLoader
     private HttpClientConfig $httpConfig;
 
     public function __construct(
-        private readonly ClientInterface $httpClient,
-        private readonly RequestFactoryInterface $requestFactory,
+        private readonly ?ClientInterface $httpClient = null,
+        private readonly ?RequestFactoryInterface $requestFactory = null,
         private readonly ?ImageFactory $imageFactory = null,
         ?ExtensionChecker $extensionChecker = null,
         ?string $preferredDriver = null,
@@ -44,8 +45,18 @@ class ImageLoader
 
     public function load(string $source): ImageInterface
     {
+        $isUrl = filter_var($source, FILTER_VALIDATE_URL) !== false;
+
+        // Fail fast (and unwrapped) before any network work when a URL is
+        // requested but no HTTP client is available. Loading a local file path
+        // never needs an HTTP client, so that path is left untouched.
+        if ($isUrl) {
+            $this->requireHttpClient();
+            $this->requireRequestFactory();
+        }
+
         try {
-            if (filter_var($source, FILTER_VALIDATE_URL)) {
+            if ($isUrl) {
                 $this->validateUrl($source);
 
                 return $this->loadFromUrl($source);
@@ -69,6 +80,43 @@ class ImageLoader
 
         // Check if source is an existing file path
         return file_exists($source);
+    }
+
+    /**
+     * Return the configured PSR-18 client, or throw if none is available.
+     *
+     * @throws RuntimeException If no HTTP client was provided/discovered
+     */
+    private function requireHttpClient(): ClientInterface
+    {
+        if ($this->httpClient === null) {
+            throw new RuntimeException(
+                'No PSR-18 HTTP client is available to load images from URLs. Install '
+                .'symfony/http-client (recommended) or any PSR-18 client, or pass your '
+                .'own client to ImageLoaderFactory / ImageLoader. Loading images from a '
+                .'local file path does not require an HTTP client.'
+            );
+        }
+
+        return $this->httpClient;
+    }
+
+    /**
+     * Return the configured PSR-17 request factory, or throw if none is available.
+     *
+     * @throws RuntimeException If no request factory was provided/discovered
+     */
+    private function requireRequestFactory(): RequestFactoryInterface
+    {
+        if ($this->requestFactory === null) {
+            throw new RuntimeException(
+                'No PSR-17 request factory is available to load images from URLs. Install '
+                .'a PSR-17 implementation (e.g. nyholm/psr7) or pass one to '
+                .'ImageLoaderFactory / ImageLoader.'
+            );
+        }
+
+        return $this->requestFactory;
     }
 
     private function loadFromPath(string $path): ImageInterface
@@ -171,14 +219,16 @@ class ImageLoader
      */
     private function sendRequestFollowingRedirects(string $url): ResponseInterface
     {
+        $httpClient = $this->requireHttpClient();
+        $requestFactory = $this->requireRequestFactory();
         $maxRedirects = $this->httpConfig->getMaxRedirects();
         $currentUrl = $url;
 
         for ($redirect = 0; ; $redirect++) {
-            $request = $this->requestFactory->createRequest('GET', $currentUrl)
+            $request = $requestFactory->createRequest('GET', $currentUrl)
                 ->withHeader('User-Agent', $this->httpConfig->getUserAgent());
 
-            $response = $this->httpClient->sendRequest($request);
+            $response = $httpClient->sendRequest($request);
 
             $status = $response->getStatusCode();
 

--- a/src/ImageLoaderFactory.php
+++ b/src/ImageLoaderFactory.php
@@ -10,7 +10,6 @@ use Http\Discovery\Psr17FactoryDiscovery;
 use Http\Discovery\Psr18ClientDiscovery;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
-use RuntimeException;
 use Symfony\Component\HttpClient\HttpClient;
 use Symfony\Component\HttpClient\Psr18Client;
 
@@ -48,11 +47,11 @@ class ImageLoaderFactory
      * HttpClient is installed we build a securely-configured instance (redirects
      * disabled at the transport layer so ImageLoader can follow + re-validate
      * each hop against the SSRF rules); otherwise we discover any PSR-18 client
-     * the project provides. If none is available, URL loading is unsupported.
-     *
-     * @throws RuntimeException If no PSR-18 client can be resolved
+     * the project provides. Returns null when none is available so that local
+     * file loading still works without an HTTP client — ImageLoader raises a
+     * clear error only if a URL is actually loaded.
      */
-    private function resolveHttpClient(HttpClientConfig $config): ClientInterface
+    private function resolveHttpClient(HttpClientConfig $config): ?ClientInterface
     {
         if (class_exists(Psr18Client::class) && class_exists(HttpClient::class)) {
             return new Psr18Client(HttpClient::create([
@@ -73,16 +72,11 @@ class ImageLoaderFactory
             try {
                 return Psr18ClientDiscovery::find();
             } catch (\Throwable) {
-                // Fall through to the explicit error below.
+                // No discoverable client — fall through and return null.
             }
         }
 
-        throw new RuntimeException(
-            'No PSR-18 HTTP client is available to load images from URLs. Install '
-            .'symfony/http-client (recommended) or any PSR-18 client, or pass your '
-            .'own client to ImageLoaderFactory / ImageLoader. Loading images from a '
-            .'local file path does not require an HTTP client.'
-        );
+        return null;
     }
 
     /**
@@ -90,10 +84,9 @@ class ImageLoaderFactory
      *
      * Many PSR-18 clients (e.g. Symfony's Psr18Client) also implement PSR-17, so
      * the client itself is reused when possible; otherwise a factory is discovered.
-     *
-     * @throws RuntimeException If no PSR-17 request factory can be resolved
+     * Returns null when none is available (see resolveHttpClient()).
      */
-    private function resolveRequestFactory(ClientInterface $client): RequestFactoryInterface
+    private function resolveRequestFactory(?ClientInterface $client): ?RequestFactoryInterface
     {
         if ($client instanceof RequestFactoryInterface) {
             return $client;
@@ -103,13 +96,10 @@ class ImageLoaderFactory
             try {
                 return Psr17FactoryDiscovery::findRequestFactory();
             } catch (\Throwable) {
-                // Fall through to the explicit error below.
+                // No discoverable factory — fall through and return null.
             }
         }
 
-        throw new RuntimeException(
-            'No PSR-17 request factory is available. Install a PSR-17 implementation '
-            .'(e.g. nyholm/psr7) or pass one to ImageLoaderFactory / ImageLoader.'
-        );
+        return null;
     }
 }

--- a/tests/Unit/AbstractColorExtractorTest.php
+++ b/tests/Unit/AbstractColorExtractorTest.php
@@ -242,3 +242,25 @@ test('it produces idempotent results with same input', function () {
     // Should produce identical results
     expect($palette1->toArray())->toBe($palette2->toArray());
 });
+
+test('extract() does not mutate the global random number generator', function () {
+    $this->extractor->setMockColors([
+        ['r' => 200, 'g' => 10, 'b' => 10, 'count' => 50],
+        ['r' => 10, 'g' => 200, 'b' => 10, 'count' => 40],
+        ['r' => 10, 'g' => 10, 'b' => 200, 'count' => 30],
+        ['r' => 200, 'g' => 200, 'b' => 10, 'count' => 20],
+    ]);
+
+    // Record the caller's global RNG sequence from a known seed.
+    mt_srand(12345);
+    $expected = [mt_rand(), mt_rand(), mt_rand()];
+
+    // Re-seed identically, then run extraction. A library must not hijack the
+    // caller's global RNG state (the old implementation called mt_srand()/mt_rand()
+    // internally, which reseeded the global generator as a side effect).
+    mt_srand(12345);
+    $this->extractor->extract($this->mockImage, 4);
+    $actual = [mt_rand(), mt_rand(), mt_rand()];
+
+    expect($actual)->toBe($expected);
+});

--- a/tests/Unit/ImageLoaderTest.php
+++ b/tests/Unit/ImageLoaderTest.php
@@ -337,3 +337,19 @@ describe('ImageLoader edge cases', function () {
         expect(true)->toBeTrue();
     });
 });
+
+test('it loads a local file without any HTTP client', function () {
+    // Headline 2.0 promise: local-file extraction must work with no HTTP client.
+    $loader = new ImageLoader(httpClient: null, requestFactory: null);
+
+    $image = $loader->load(__DIR__.'/../../example/assets/sample.jpg');
+
+    expect($image->getWidth())->toBeGreaterThan(0);
+});
+
+test('it fails with a clear error when loading a URL without an HTTP client', function () {
+    $loader = new ImageLoader(httpClient: null, requestFactory: null);
+
+    expect(fn () => $loader->load('https://example.com/image.jpg'))
+        ->toThrow(RuntimeException::class, 'No PSR-18 HTTP client');
+});


### PR DESCRIPTION
Final pre-2.0 pass (items 1–4 from the major-readiness review).

## Changes
1. **`.gitattributes`** — export-ignore `/example` (the web-ui demo shipped in **every** install), `/phpstan.neon.dist`, and contributor docs; drop stale entries for files that no longer exist (psalm, php-cs-fixer, art, docs). → slimmer `composer require` download.
2. **`composer.json`** — `minimum-stability`: `dev` → `stable` (released library shouldn't accept dev deps).
3. **`UPGRADING.md`** — documents the 1.x → 2.0 changes (PHP 8.2, optional HTTP client, removed `HTTP_OK`).
4. **`fix(extractor)`** — `initializeCentroids()` no longer calls `mt_srand()`/`mt_rand()` (which reseeded PHP's **global** RNG, hijacking the caller's `mt_rand()` sequence). Uses a locally-seeded `\Random\Randomizer` (Mt19937) — deterministic + idempotent, no global side effect. TDD: added a test asserting extraction leaves the caller's global RNG sequence untouched.

## Note
The RNG change can shift an extracted palette slightly on complex images (different int-ranging than `mt_rand()`); determinism and idempotency are preserved. Hence a major release.

## Verification
- `composer test` → 963 passed, 40 skipped (incl. new global-RNG-isolation test; idempotency tests still pass)
- `composer analyse` → No errors (level 6)
- `composer format` → clean
- `composer validate` → valid; `minimum-stability: stable` resolves with no changes