### PR TITLE
docs(upgrading): clarify extraction output may differ from 1.x

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -3,15 +3,19 @@
 ## Upgrading from 1.x to 2.0
 
 Version 2.0 focuses on a lighter dependency footprint and a higher minimum PHP
-version. The public API of color conversion, manipulation, analysis, and palette
-generation is **unchanged**; the breaking changes are limited to the minimum PHP
-version and to loading images from remote URLs.
+version. The public API of color extraction, conversion, manipulation, analysis,
+and palette generation is **unchanged**; the breaking changes are limited to the
+minimum PHP version and to loading images from remote URLs.
 
-> **Note on extracted colors:** the k-means image extractor's centroid seeding
-> moved off PHP's global `mt_rand()` to a locally-seeded `\Random\Randomizer`
-> (so extraction no longer mutates your global RNG state). Results remain
-> deterministic and idempotent, but the exact colors extracted from a given
-> image with `count > 1` may differ slightly from 1.x.
+> **Behavior change — extracted colors.** The color-extraction **algorithm and
+> public API are unchanged**, but the k-means centroid **seeding** moved off
+> PHP's global `mt_rand()` to a locally-seeded
+> `\Random\Randomizer(new \Random\Engine\Mt19937($seed))` so that extraction no
+> longer mutates your application's global RNG state. As a result, the exact
+> colors extracted from a given image **may differ slightly from 1.x** when more
+> than one color is requested (`count > 1`). Extraction stays **deterministic
+> within 2.0** — the same image always yields the same palette — so if you cache
+> or snapshot extracted palettes, re-baseline them after upgrading.
 
 ### 1. PHP 8.2 is now required
 


### PR DESCRIPTION
Sharpens the 2.0 upgrade note about the k-means RNG-seeding change (commit 37933b2).

PR #42 already softened this (dropped 'extraction' from the unchanged list + added a callout), but the wording didn't explicitly state the requested framing. This:
- re-includes **extraction** in the *unchanged algorithm/API* statement, and
- reframes the caveat as a **Behavior change**: centroid *seeding* moved off PHP's global `mt_rand()` to a local `\Random\Randomizer(new Mt19937($seed))`, so exact extracted colors **may differ from 1.x for `count > 1`**, while staying **deterministic within 2.0**.

Docs only — no code change.

Note: the **CHANGELOG.md 2.0.0 entry is auto-generated** from the GitHub release body by `update-changelog.yml` on publish, and the drafted 2.0.0 release notes already carry this caveat — so it will appear in the changelog on tag. A manual 2.0.0 entry now would duplicate when the workflow runs, so CHANGELOG is intentionally left untouched.