### PR TITLE
docs(security): warn that non-Symfony PSR-18 clients can bypass redirect SSRF checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -604,6 +604,25 @@ $loader->load('file:///etc/passwd');                    // Blocked
 $loader->load('https://example.com/public-image.jpg'); // OK
 ```
 
+#### Choosing an HTTP Client (redirect safety)
+
+The loader follows redirects itself and **re-validates every hop** against the
+SSRF rules above — but only if the underlying PSR-18 client does **not** follow
+redirects on its own. The default does this correctly: when `symfony/http-client`
+is installed, the factory configures it with `max_redirects = 0`.
+
+> ⚠️ **A different PSR-18 client (e.g. Guzzle) may follow redirects internally by
+> default**, which bypasses the per-hop re-validation — a redirect from a public
+> URL to an internal address would be followed before the loader can check it.
+> When accepting user-supplied URLs, prefer `symfony/http-client`, or inject a
+> client configured **not** to follow redirects:
+>
+> ```php
+> // Guzzle: disable redirect-following so the loader re-validates each hop
+> $client = new \GuzzleHttp\Client(['allow_redirects' => false]);
+> $loader = (new \Farzai\ColorPalette\ImageLoaderFactory(httpClient: $client))->create();
+> ```
+
 #### File Size Limits
 
 Downloaded files are limited to **10MB by default** to prevent denial-of-service attacks:

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -43,8 +43,12 @@ composer require symfony/http-client   # recommended
 # or: composer require guzzlehttp/guzzle
 ```
 
-`symfony/http-client` is recommended because the factory configures it to not
-follow redirects, so every redirect hop is re-validated against the SSRF rules.
+`symfony/http-client` is recommended because the factory configures it with
+`max_redirects = 0`, so the loader re-validates every redirect hop against the
+SSRF rules. **Other PSR-18 clients (e.g. Guzzle) may follow redirects internally
+by default, which bypasses that per-hop check** — when accepting user-supplied
+URLs, prefer `symfony/http-client` or inject a client configured not to follow
+redirects (e.g. Guzzle's `['allow_redirects' => false]`).
 
 Nothing else changes — this keeps working once a client is present:
 

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
     },
     "suggest": {
         "symfony/http-client": "Recommended PSR-18 client for loading images from remote URLs; the factory configures it to not follow redirects for SSRF safety",
-        "guzzlehttp/guzzle": "Alternative PSR-18 client (auto-discovered) for loading images from remote URLs",
+        "guzzlehttp/guzzle": "Alternative PSR-18 client (auto-discovered). When loading user-supplied URLs, configure it with allow_redirects=false (or inject it) so the loader's per-hop SSRF re-validation is not bypassed",
         "nyholm/psr7": "Lightweight PSR-17 request factory, if your PSR-18 client does not provide one"
     },
     "autoload": {


### PR DESCRIPTION
The only `adjust_now` item from the final 2.0 review (zero tag-blockers otherwise).

## Why
`ImageLoader` follows redirects itself and re-validates **every hop** against the SSRF rules — but only if the underlying PSR-18 client does **not** follow redirects. The factory configures the recommended `symfony/http-client` with `max_redirects=0`, but an **auto-discovered/default Guzzle** client follows redirects internally, silently turning the per-hop re-validation into a no-op. The docs recommended Guzzle as an alternative **without** this caveat.

## Changes (docs only)
- **README → Security**: new "Choosing an HTTP Client (redirect safety)" subsection with the caveat + a Guzzle `allow_redirects => false` / inject-your-own example.
- **UPGRADING.md §2**: extend the client-choice note with the same warning.
- **composer.json `suggest`**: guzzle entry now notes `allow_redirects=false` for user-supplied URLs.

No code change.