### PR TITLE
fix: align builder image driver and guard k-means against zero weight

### DIFF
--- a/example/web-ui/api.php
+++ b/example/web-ui/api.php
@@ -96,7 +96,10 @@ function handleExtract()
             // file_get_contents(): it validates the scheme, blocks private/reserved
             // IPs (re-checking every redirect hop), and enforces the byte-size and
             // decoded-dimension limits before the image is ever decoded.
-            $image = (new ImageLoaderFactory)->create()->load($url);
+            // Load with the same 'gd' driver the extractor uses (otherwise the
+            // loader's auto-detected driver could yield an image the gd extractor
+            // can't read, silently falling back to a grayscale palette).
+            $image = (new ImageLoaderFactory(preferredDriver: 'gd'))->create()->load($url);
             $palette = (new ColorExtractorFactory)->make('gd')->extract($image, $count);
             assert($palette instanceof ColorPalette);
 

--- a/src/AbstractColorExtractor.php
+++ b/src/AbstractColorExtractor.php
@@ -244,6 +244,14 @@ abstract class AbstractColorExtractor implements ColorExtractorInterface
                     $totalWeight += $weight;
                 }
 
+                // A cluster of zero-weight colors (e.g. a custom extractor emitting
+                // count=0) would divide by zero; keep the previous centroid instead.
+                if ($totalWeight <= 0) {
+                    $newCentroids[$i] = $centroids[$i];
+
+                    continue;
+                }
+
                 $newCentroids[$i] = [
                     'r' => (int) round($sumR / $totalWeight),
                     'g' => (int) round($sumG / $totalWeight),

--- a/src/ColorPaletteBuilder.php
+++ b/src/ColorPaletteBuilder.php
@@ -208,7 +208,11 @@ class ColorPaletteBuilder
             return new ColorPalette([]);
         }
 
-        $loader = (new ImageLoaderFactory)->create();
+        // Load with the SAME driver the extractor uses, otherwise the loader's
+        // auto-detected driver (e.g. imagick when available) yields an image type
+        // the gd extractor can't read — extract() would catch the TypeError and
+        // silently fall back to a grayscale palette.
+        $loader = (new ImageLoaderFactory(preferredDriver: $this->driver))->create();
         $image = $loader->load($this->imagePath);
 
         $extractorFactory = new ColorExtractorFactory;

--- a/tests/Unit/AbstractColorExtractorTest.php
+++ b/tests/Unit/AbstractColorExtractorTest.php
@@ -264,3 +264,16 @@ test('extract() does not mutate the global random number generator', function ()
 
     expect($actual)->toBe($expected);
 });
+
+test('clusterColors does not divide by zero when a cluster has zero total weight', function () {
+    // A custom extractor can emit colors with count=0; their weighted-centroid
+    // average must not divide by a zero total weight.
+    $colors = [
+        ['r' => 200, 'g' => 10, 'b' => 10, 'count' => 0],
+        ['r' => 10, 'g' => 200, 'b' => 10, 'count' => 0],
+    ];
+
+    $result = $this->extractor->publicClusterColors($colors, 2);
+
+    expect($result)->toBeArray()->toHaveCount(2);
+});

--- a/tests/Unit/ColorPaletteBuilderTest.php
+++ b/tests/Unit/ColorPaletteBuilderTest.php
@@ -493,3 +493,26 @@ describe('ColorPaletteBuilder Complex Workflows', function () {
         expect($palette->count())->toBe(10);
     });
 });
+
+describe('ColorPaletteBuilder image driver alignment', function () {
+    test('build() extracts real colors with the requested driver (no grayscale fallback on a driver mismatch)', function () {
+        if (! extension_loaded('gd')) {
+            $this->markTestSkipped('GD extension required.');
+        }
+
+        // The builder must load the image with the SAME driver the extractor uses.
+        // If the loader auto-detects a different driver (e.g. imagick when present)
+        // than the 'gd' extractor, the mismatch makes extract() fall back to a
+        // grayscale palette. sample.jpg is solid red, so a grayscale fallback
+        // (r≈g≈b) is distinguishable from a correct red extraction.
+        $palette = ColorPaletteBuilder::create()
+            ->withDriver('gd')
+            ->fromImage(__DIR__.'/../../example/assets/sample.jpg')
+            ->withCount(3)
+            ->build();
+
+        expect($palette)->toBeInstanceOf(ColorPalette::class);
+        $top = $palette->getColors()[0];
+        expect($top->getRed())->toBeGreaterThan($top->getBlue() + 30);
+    });
+});


### PR DESCRIPTION
Two robustness fixes pulled forward from the 2.1 backlog (per request, before tagging 2.0.0).

## 1. Builder driver mismatch → silent grayscale
`ColorPaletteBuilder::buildFromImage()` built the loader with an **auto-detected** driver but extracted with `$this->driver` (default `gd`). On an **imagick-present** host the loader returns an `ImagickImage`, the gd extractor throws a TypeError, `extract()` catches it, and the builder **silently returns a grayscale palette**. Now loads with `preferredDriver: $this->driver`. Same mismatch fixed in the web-ui demo's URL path.

## 2. k-means zero-weight division
`clusterColors()` divided weighted RGB sums by a cluster's total `count` weight → `DivisionByZeroError` if a custom extractor emits `count=0` (swallowed into the grayscale fallback). Now keeps the previous centroid when total weight ≤ 0.

## Tests
- `clusterColors does not divide by zero when a cluster has zero total weight` (was `DivisionByZeroError`).
- `build() extracts real colors with the requested driver` — discriminates the grayscale fallback, catching the mismatch on imagick-present CI hosts.

## Verification
- `composer test` → 967 passed, 40 skipped
- `composer analyse` → No errors (level 6); `composer format` → clean