### PR TITLE
chore: implement ImageLoaderInterface, fix @throws, and final 2.0 doc notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -728,8 +728,9 @@ try {
     throw new UserFacingException('Invalid URL provided');
 }
 
-// ✗ BAD: Don't blindly trust user input
-$image = (new ImageLoaderFactory)->create()->load($_GET['url']); // validate first!
+// ⚠️ The loader already validates the URL against the SSRF rules, but for
+// untrusted input add an allowlist for defense in depth (see below).
+$image = (new ImageLoaderFactory)->create()->load($_GET['url']);
 
 // ✓ GOOD: Add URL whitelist for extra security
 $allowedDomains = ['cdn.example.com', 'images.example.com'];

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -80,3 +80,10 @@ factory are now optional and default to `null`.
 The unused public constant `Farzai\ColorPalette\Constants\ImageConstants::HTTP_OK`
 was removed. It was never referenced by the library. If you referenced it, use
 the literal `200` instead.
+
+### 4. `GdImage::__destruct()` removed
+
+`Farzai\ColorPalette\Images\GdImage` no longer defines a `__destruct()` method.
+On PHP 8+, `\GdImage` objects are reference-counted and freed automatically, so
+the explicit `imagedestroy()` was unnecessary. This is internal cleanup only —
+there is nothing to call and no behavior to migrate.

--- a/src/ColorAnalyzer.php
+++ b/src/ColorAnalyzer.php
@@ -236,6 +236,8 @@ class ColorAnalyzer
      * Determine if a color is a warm color
      *
      * Warm colors are red, orange, and yellow hues (roughly 0-60 degrees on the color wheel).
+     * Hues in 61-119 (yellow-green) and 301-360 (magenta/pink) are intentionally
+     * classified as neither warm nor cool, so isWarm() and isCool() can both be false.
      *
      * @param  ColorInterface  $color  The color to check
      * @return bool True if the color is warm
@@ -253,6 +255,8 @@ class ColorAnalyzer
      * Determine if a color is a cool color
      *
      * Cool colors are green, blue, and purple hues (roughly 120-300 degrees on the color wheel).
+     * Hues outside the warm (0-60) and cool (120-300) bands are intentionally
+     * classified as neither, so isWarm() and isCool() can both be false.
      *
      * @param  ColorInterface  $color  The color to check
      * @return bool True if the color is cool

--- a/src/Contracts/ImageLoaderInterface.php
+++ b/src/Contracts/ImageLoaderInterface.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Farzai\ColorPalette\Contracts;
 
-use Farzai\ColorPalette\Exceptions\ImageLoadException;
+use Farzai\ColorPalette\Exceptions\InvalidImageException;
 
 /**
  * Interface for handling image loading operations
@@ -16,7 +16,10 @@ interface ImageLoaderInterface
      *
      * @param  string  $source  Image source (URL or file path)
      *
-     * @throws ImageLoadException
+     * @throws InvalidImageException If the image cannot be loaded (also covers its
+     *                               HttpException and SsrfException subclasses)
+     * @throws \RuntimeException If a URL is requested but no PSR-18 client / PSR-17
+     *                           request factory is available
      */
     public function load(string $source): ImageInterface;
 

--- a/src/ImageLoader.php
+++ b/src/ImageLoader.php
@@ -7,6 +7,7 @@ namespace Farzai\ColorPalette;
 use Farzai\ColorPalette\Config\HttpClientConfig;
 use Farzai\ColorPalette\Constants\ImageConstants;
 use Farzai\ColorPalette\Contracts\ImageInterface;
+use Farzai\ColorPalette\Contracts\ImageLoaderInterface;
 use Farzai\ColorPalette\Exceptions\HttpException;
 use Farzai\ColorPalette\Exceptions\InvalidImageException;
 use Farzai\ColorPalette\Exceptions\SsrfException;
@@ -17,7 +18,7 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;
 use RuntimeException;
 
-class ImageLoader
+class ImageLoader implements ImageLoaderInterface
 {
     private string $preferredDriver;
 

--- a/tests/Unit/ImageLoaderTest.php
+++ b/tests/Unit/ImageLoaderTest.php
@@ -353,3 +353,12 @@ test('it fails with a clear error when loading a URL without an HTTP client', fu
     expect(fn () => $loader->load('https://example.com/image.jpg'))
         ->toThrow(RuntimeException::class, 'No PSR-18 HTTP client');
 });
+
+test('it fails with a clear error when loading a URL without a PSR-17 request factory', function () {
+    // A client that is not also a request factory, with no factory provided.
+    $client = Mockery::mock(ClientInterface::class);
+    $loader = new ImageLoader(httpClient: $client, requestFactory: null);
+
+    expect(fn () => $loader->load('https://example.com/image.jpg'))
+        ->toThrow(RuntimeException::class, 'No PSR-17 request factory');
+});


### PR DESCRIPTION
Final backlog cleanup before tagging 2.0.0 (annotations/docs/coverage; no behavior change).

## Changes
- **`ImageLoader implements ImageLoaderInterface`** — the interface was orphaned (no implementer) and its `@throws` claimed `ImageLoadException`, which `load()` never throws. Corrected to `InvalidImageException` (base of `HttpException`/`SsrfException`) + `\RuntimeException` (missing PSR-18 client / PSR-17 factory).
- **Test**: cover the "no PSR-17 request factory" URL-load error path.
- **Docs**: `isWarm()`/`isCool()` docblocks note the intentional neutral hue bands (61-119, 301-360); UPGRADING notes `GdImage::__destruct()` removal (PHP 8 auto-frees `\GdImage`); README user-URL "BAD" comment clarified (loader already validates SSRF; allowlist = defense in depth).

## Verification
- `composer test` → 968 passed, 40 skipped
- `composer analyse` → No errors (level 6); `composer format` → clean