### PR TITLE
feat!: add a Driver enum and formalize ImageInterface::getResource()

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -87,3 +87,35 @@ the literal `200` instead.
 On PHP 8+, `\GdImage` objects are reference-counted and freed automatically, so
 the explicit `imagedestroy()` was unnecessary. This is internal cleanup only —
 there is nothing to call and no behavior to migrate.
+
+### 5. `ImageInterface` now declares `getResource()`
+
+`Farzai\ColorPalette\Contracts\ImageInterface` now declares
+`public function getResource(): mixed`, formalising the accessor the color
+extractors already relied on. The bundled `GdImage` and `ImagickImage` already
+implement it, so no change is needed for normal use.
+
+**If you have a custom `ImageInterface` implementation**, add the method:
+
+```php
+public function getResource(): mixed
+{
+    return $this->resource; // your \GdImage, \Imagick, or other backend handle
+}
+```
+
+## New (non-breaking)
+
+### A `Driver` enum for image drivers
+
+You can now pass a `Farzai\ColorPalette\Enums\Driver` enum anywhere a driver was
+given as a string (`ColorExtractorFactory::make()`, `ImageFactory::fromPath()` /
+`createFromPath()`, `ColorPalette::fromImage()`, `ColorPaletteBuilder::withDriver()`):
+
+```php
+use Farzai\ColorPalette\Enums\Driver;
+
+$palette = ColorPalette::fromImage('photo.jpg', 5, Driver::Imagick);
+```
+
+Plain strings (`'gd'` / `'imagick'`) keep working — this is additive.

--- a/src/ColorExtractorFactory.php
+++ b/src/ColorExtractorFactory.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Farzai\ColorPalette;
 
+use Farzai\ColorPalette\Enums\Driver;
 use Farzai\ColorPalette\Services\ExtensionChecker;
 use InvalidArgumentException;
 use Psr\Log\LoggerInterface;
@@ -77,10 +78,14 @@ class ColorExtractorFactory
     /**
      * Create a new color extractor instance
      *
+     * @param  Driver|string  $driver  The image driver ('gd' or 'imagick', or a Driver enum)
+     *
      * @throws InvalidArgumentException If an unsupported driver is specified
      */
-    public function make(string $driver = 'gd'): AbstractColorExtractor
+    public function make(Driver|string $driver = 'gd'): AbstractColorExtractor
     {
+        $driver = Driver::normalize($driver);
+
         return match ($driver) {
             'gd' => $this->createGdExtractor(),
             'imagick' => $this->createImagickExtractor(),

--- a/src/ColorPalette.php
+++ b/src/ColorPalette.php
@@ -10,6 +10,7 @@ use Countable;
 use Farzai\ColorPalette\Constants\AccessibilityConstants;
 use Farzai\ColorPalette\Contracts\ColorInterface;
 use Farzai\ColorPalette\Contracts\ColorPaletteInterface;
+use Farzai\ColorPalette\Enums\Driver;
 use IteratorAggregate;
 
 /**
@@ -57,7 +58,7 @@ class ColorPalette implements ArrayAccess, ColorPaletteInterface, Countable, Ite
      * $colors = $palette->toArray();
      * ```
      */
-    public static function fromImage(string $path, int $count = 5, string $driver = 'gd'): self
+    public static function fromImage(string $path, int $count = 5, Driver|string $driver = 'gd'): self
     {
         $imageFactory = new ImageFactory;
         $image = $imageFactory->createFromPath($path, $driver);

--- a/src/ColorPaletteBuilder.php
+++ b/src/ColorPaletteBuilder.php
@@ -6,6 +6,7 @@ namespace Farzai\ColorPalette;
 
 use Farzai\ColorPalette\Contracts\ColorInterface;
 use Farzai\ColorPalette\Contracts\PaletteGenerationStrategyInterface;
+use Farzai\ColorPalette\Enums\Driver;
 
 /**
  * Fluent builder for creating ColorPalette instances
@@ -163,12 +164,12 @@ class ColorPaletteBuilder
     /**
      * Set the image processing driver
      *
-     * @param  string  $driver  Driver name: 'gd' or 'imagick'
+     * @param  Driver|string  $driver  Driver name ('gd' or 'imagick') or a Driver enum
      * @return $this
      */
-    public function withDriver(string $driver): self
+    public function withDriver(Driver|string $driver): self
     {
-        $this->driver = $driver;
+        $this->driver = Driver::normalize($driver);
 
         return $this;
     }

--- a/src/Contracts/ImageInterface.php
+++ b/src/Contracts/ImageInterface.php
@@ -18,4 +18,12 @@ interface ImageInterface
      * Get image height
      */
     public function getHeight(): int;
+
+    /**
+     * Get the underlying driver resource.
+     *
+     * Returns the backend-specific handle (e.g. a \GdImage or \Imagick instance);
+     * implementations narrow this to their concrete resource type.
+     */
+    public function getResource(): mixed;
 }

--- a/src/Enums/Driver.php
+++ b/src/Enums/Driver.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Farzai\ColorPalette\Enums;
+
+/**
+ * Supported image-processing drivers.
+ */
+enum Driver: string
+{
+    case Gd = 'gd';
+
+    case Imagick = 'imagick';
+
+    /**
+     * Normalize a Driver|string driver identifier to its string value.
+     */
+    public static function normalize(self|string $driver): string
+    {
+        return $driver instanceof self ? $driver->value : $driver;
+    }
+}

--- a/src/GdColorExtractor.php
+++ b/src/GdColorExtractor.php
@@ -6,24 +6,15 @@ namespace Farzai\ColorPalette;
 
 use Farzai\ColorPalette\Contracts\ImageInterface;
 use Farzai\ColorPalette\Images\GdImage;
-use InvalidArgumentException;
 
 class GdColorExtractor extends AbstractColorExtractor
 {
     protected function extractColors(ImageInterface $image): array
     {
-        /**
-         * Note: This extractor is designed to work with GdImage instances.
-         * The type check has been removed to reduce coupling, but proper
-         * image/extractor pairing should be ensured by the factory.
-         */
-        if (! method_exists($image, 'getResource')) {
-            throw new InvalidArgumentException(
-                'Image must provide getResource() method. '.
-                'GdColorExtractor works with GdImage instances.'
-            );
-        }
-
+        // ImageInterface guarantees getResource(); a GdImage yields the \GdImage
+        // handle the GD functions below operate on. A mismatched image type (e.g.
+        // an ImagickImage) surfaces as a TypeError, which extract() turns into the
+        // grayscale fallback.
         $gdImage = $image->getResource();
         $width = imagesx($gdImage);
         $height = imagesy($gdImage);

--- a/src/ImageFactory.php
+++ b/src/ImageFactory.php
@@ -6,6 +6,7 @@ namespace Farzai\ColorPalette;
 
 use Farzai\ColorPalette\Constants\ImageConstants;
 use Farzai\ColorPalette\Contracts\ImageInterface;
+use Farzai\ColorPalette\Enums\Driver;
 use Farzai\ColorPalette\Images\GdImage;
 use Farzai\ColorPalette\Images\ImagickImage;
 use Farzai\ColorPalette\Services\ExtensionChecker;
@@ -31,13 +32,15 @@ class ImageFactory
      * $image = ImageFactory::fromPath('photo.jpg', 'imagick');
      * ```
      */
-    public static function fromPath(string $path, string $driver = 'gd'): ImageInterface
+    public static function fromPath(string $path, Driver|string $driver = 'gd'): ImageInterface
     {
         return (new self)->createFromPath($path, $driver);
     }
 
-    public function createFromPath(string $path, string $driver = 'gd'): ImageInterface
+    public function createFromPath(string $path, Driver|string $driver = 'gd'): ImageInterface
     {
+        $driver = Driver::normalize($driver);
+
         return match ($driver) {
             'gd' => $this->createGdImage($path),
             'imagick' => $this->createImagickImage($path),

--- a/src/ImagickColorExtractor.php
+++ b/src/ImagickColorExtractor.php
@@ -17,18 +17,9 @@ class ImagickColorExtractor extends AbstractColorExtractor
      */
     protected function extractColors(ImageInterface $image): array
     {
-        /**
-         * Note: This extractor is designed to work with ImagickImage instances.
-         * The type check has been removed to reduce coupling, but proper
-         * image/extractor pairing should be ensured by the factory.
-         */
-        if (! method_exists($image, 'getResource')) {
-            throw new \InvalidArgumentException(
-                'Image must provide getResource() method. '.
-                'ImagickColorExtractor works with ImagickImage instances.'
-            );
-        }
-
+        // ImageInterface guarantees getResource(); an ImagickImage yields the
+        // \Imagick handle used below. A mismatched image type surfaces as a
+        // TypeError, which extract() turns into the grayscale fallback.
         $imagick = $image->getResource();
 
         // Resize image for faster processing

--- a/tests/Unit/ColorExtractor/GdColorExtractorTest.php
+++ b/tests/Unit/ColorExtractor/GdColorExtractorTest.php
@@ -113,32 +113,6 @@ describe('GdColorExtractor - Error Handling', function () {
         // Should return grayscale fallback
         expect($palette[0]->toHex())->toBe('#ffffff');
     });
-
-    test('it throws exception when image lacks getResource method', function () {
-        if (! extension_loaded('gd')) {
-            $this->markTestSkipped('GD extension is not available.');
-        }
-
-        // Create a mock without getResource method
-        $mockImage = new class implements ImageInterface
-        {
-            public function getWidth(): int
-            {
-                return 100;
-            }
-
-            public function getHeight(): int
-            {
-                return 100;
-            }
-        };
-
-        $extractor = new GdColorExtractor;
-
-        // Should return fallback because the error is caught in AbstractColorExtractor
-        $palette = $extractor->extract($mockImage, 5);
-        expect($palette)->toHaveCount(5);
-    });
 });
 
 describe('GdColorExtractor - Color Filtering', function () {

--- a/tests/Unit/ColorExtractorFactoryTest.php
+++ b/tests/Unit/ColorExtractorFactoryTest.php
@@ -1,10 +1,19 @@
 <?php
 
 use Farzai\ColorPalette\ColorExtractorFactory;
+use Farzai\ColorPalette\Enums\Driver;
 use Farzai\ColorPalette\GdColorExtractor;
 use Farzai\ColorPalette\ImagickColorExtractor;
 use Farzai\ColorPalette\Services\ExtensionChecker;
 use Psr\Log\NullLogger;
+
+test('make() accepts a Driver enum', function () {
+    if (! extension_loaded('gd')) {
+        $this->markTestSkipped('GD extension is not available.');
+    }
+
+    expect((new ColorExtractorFactory)->make(Driver::Gd))->toBeInstanceOf(GdColorExtractor::class);
+});
 
 test('it creates GD extractor when GD is available', function () {
     if (! extension_loaded('gd')) {

--- a/tests/Unit/ColorPaletteBuilderTest.php
+++ b/tests/Unit/ColorPaletteBuilderTest.php
@@ -3,6 +3,7 @@
 use Farzai\ColorPalette\Color;
 use Farzai\ColorPalette\ColorPalette;
 use Farzai\ColorPalette\ColorPaletteBuilder;
+use Farzai\ColorPalette\Enums\Driver;
 use Farzai\ColorPalette\Strategies\MonochromaticStrategy;
 
 describe('ColorPaletteBuilder Basic Operations', function () {
@@ -514,5 +515,20 @@ describe('ColorPaletteBuilder image driver alignment', function () {
         expect($palette)->toBeInstanceOf(ColorPalette::class);
         $top = $palette->getColors()[0];
         expect($top->getRed())->toBeGreaterThan($top->getBlue() + 30);
+    });
+
+    test('withDriver() accepts a Driver enum', function () {
+        if (! extension_loaded('gd')) {
+            $this->markTestSkipped('GD extension required.');
+        }
+
+        $palette = ColorPaletteBuilder::create()
+            ->withDriver(Driver::Gd)
+            ->fromImage(__DIR__.'/../../example/assets/sample.jpg')
+            ->withCount(3)
+            ->build();
+
+        expect($palette)->toBeInstanceOf(ColorPalette::class);
+        expect($palette->count())->toBe(3);
     });
 });

--- a/tests/Unit/ImageFactoryTest.php
+++ b/tests/Unit/ImageFactoryTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Farzai\ColorPalette\Enums\Driver;
 use Farzai\ColorPalette\ImageFactory;
 use Farzai\ColorPalette\Images\GdImage;
 use Farzai\ColorPalette\Images\ImagickImage;
@@ -202,5 +203,15 @@ describe('ImageFactory Static Factory Methods', function () {
     test('it throws exception for unsupported driver with static method', function () {
         expect(fn () => ImageFactory::fromPath($this->testImagePath, 'invalid'))
             ->toThrow(InvalidArgumentException::class, 'Unsupported driver');
+    });
+
+    test('fromPath accepts a Driver enum', function () {
+        if (! extension_loaded('gd')) {
+            $this->markTestSkipped('GD extension is not available.');
+        }
+
+        $image = ImageFactory::fromPath($this->testImagePath, Driver::Gd);
+
+        expect($image)->toBeInstanceOf(GdImage::class);
     });
 });


### PR DESCRIPTION
The two API-design items chosen for 2.0 (per the final review's defer list).

## 1. `Driver` enum (additive, non-breaking)
New `Farzai\ColorPalette\Enums\Driver { Gd, Imagick }`. Public driver params now accept `Driver|string` — `ColorExtractorFactory::make()`, `ImageFactory::fromPath()`/`createFromPath()`, `ColorPalette::fromImage()`, `ColorPaletteBuilder::withDriver()`. Plain `'gd'`/`'imagick'` strings keep working (normalized via `Driver::normalize()`).

## 2. `getResource()` on `ImageInterface` (breaking)
`ImageInterface` now declares `getResource(): mixed` (return type kept `mixed` so the `\GdImage`/`\Imagick` call sites stay PHPStan-clean at level 6). The extractors' redundant `method_exists()` guards + dead throw paths are removed; `GdImage`/`ImagickImage` already implement it. **Breaking for custom `ImageInterface` implementers** — documented in UPGRADING §5 (an obsolete test that implemented the interface without `getResource()` was removed).

## Tests
- `make()`/`fromPath()`/`withDriver()` accept a `Driver` enum.

## Verification
- `composer test` → 970 passed, 40 skipped
- `composer analyse` → No errors (level 6); `composer format` → clean

**BREAKING CHANGE:** `ImageInterface` now declares `getResource(): mixed`.