### PR TITLE
feat!: make Theme a validated five-role value object and fix ThemeGenerator

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,12 +197,12 @@ $palette = ColorPalette::fromImage('assets/logo.png', 8);
 // Get suggested theme colors
 $theme = $palette->getSuggestedSurfaceColors();
 
-echo "Primary: " . $theme['surface']->toHex();      // #f5f5f5
+echo "Surface: " . $theme['surface']->toHex();       // #f5f5f5
 echo "Background: " . $theme['background']->toHex(); // #e8e8e8
 echo "Accent: " . $theme['accent']->toHex();         // #ff5733
 
 // Get appropriate text colors
-$textOnPrimary = $palette->getSuggestedTextColor($theme['surface']);
+$textOnSurface = $palette->getSuggestedTextColor($theme['surface']);
 $textOnAccent = $palette->getSuggestedTextColor($theme['accent']);
 ```
 
@@ -422,6 +422,31 @@ $theme = $palette->getSuggestedSurfaceColors();
 - `'background'` - Second lightest (secondary backgrounds)
 - `'accent'` - Accent color with good contrast
 - `'surface_variant'` - Variant of surface color
+
+> This is a lightweight heuristic helper that returns a plain array. For a typed,
+> validated 5-role theme, use `Theme` (below).
+
+#### Typed themes — `Theme`
+
+`Theme` is a value object that always defines the five roles `primary`,
+`secondary`, `accent`, `background`, `surface`; its getters never throw.
+
+```php
+use Farzai\ColorPalette\Color;
+use Farzai\ColorPalette\ColorPalette;
+use Farzai\ColorPalette\PaletteGenerator;
+use Farzai\ColorPalette\Theme;
+use Farzai\ColorPalette\ThemeGenerator;
+
+// Full 5-role theme from a brand color (via the website-theme strategy):
+$palette = (new PaletteGenerator(Color::fromHex('#2196F3')))->websiteTheme();
+$theme = Theme::fromPalette($palette);
+echo $theme->getPrimaryColor()->toHex();
+echo $theme->getSurfaceColor()->toHex();
+
+// Or derive a theme from any extracted palette:
+$theme = (new ThemeGenerator)->generate(ColorPalette::fromImage('logo.png', 5));
+```
 
 #### ColorPalette::getSuggestedTextColor()
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -104,6 +104,28 @@ public function getResource(): mixed
 }
 ```
 
+### 6. `Theme` is now a validated five-role value object
+
+`Theme` previously stored an arbitrary `name => color` map, so its `ThemeInterface`
+getters (`getPrimaryColor()` … `getSurfaceColor()`) threw when a role was absent —
+including on `ThemeGenerator`'s own output. A `Theme` now **always defines the five
+roles** `primary`, `secondary`, `accent`, `background`, `surface`, and the getters
+never throw.
+
+- The constructor and `Theme::fromColors()` now **throw `InvalidArgumentException`
+  if any of the five roles is missing**. If you built partial themes, populate all
+  five roles (or use the new `Theme::fromRoles(...)` / `Theme::fromPalette($palette)`).
+- `ThemeGenerator::generate()` **no longer accepts the second `$colorNames`
+  argument** (its signature now matches `ThemeGeneratorInterface`). It no longer
+  requires `count(colors) === count(names)`; instead it lifts a role-keyed palette
+  (e.g. `WebsiteThemeStrategy` output) directly, or derives all five roles from an
+  arbitrary palette. Drop the second argument:
+
+```php
+// Before: $generator->generate($palette, ['primary', 'secondary', 'accent']);
+$theme = (new ThemeGenerator)->generate($palette); // derives all five roles
+```
+
 ## New (non-breaking)
 
 ### A `Driver` enum for image drivers

--- a/src/Theme.php
+++ b/src/Theme.php
@@ -5,30 +5,44 @@ declare(strict_types=1);
 namespace Farzai\ColorPalette;
 
 use Farzai\ColorPalette\Contracts\ColorInterface;
+use Farzai\ColorPalette\Contracts\ColorPaletteInterface;
 use Farzai\ColorPalette\Contracts\ThemeInterface;
 use InvalidArgumentException;
 
 class Theme implements ThemeInterface
 {
     /**
-     * @var array<string, ColorInterface>
+     * The semantic roles every theme must define.
      */
-    private array $colors = [];
+    public const ROLES = ['primary', 'secondary', 'accent', 'background', 'surface'];
 
     /**
-     * Create a new Theme instance
-     *
-     * @param  array<string, ColorInterface>  $colors
+     * @var array<string, ColorInterface>
      */
-    public function __construct(array $colors = [])
+    private array $colors;
+
+    /**
+     * @param  array<string, ColorInterface>  $colors  Must define every role in self::ROLES
+     *
+     * @throws InvalidArgumentException If a required role is missing or is not a ColorInterface
+     */
+    public function __construct(array $colors)
     {
+        foreach (self::ROLES as $role) {
+            if (! (($colors[$role] ?? null) instanceof ColorInterface)) {
+                throw new InvalidArgumentException("Theme is missing required '{$role}' color");
+            }
+        }
+
         $this->colors = $colors;
     }
 
     /**
-     * Create a theme from colors
+     * Create a theme from a role => color map (must define all five roles).
      *
      * @param  array<string, ColorInterface>  $colors
+     *
+     * @throws InvalidArgumentException If a required role is missing
      */
     public static function fromColors(array $colors): self
     {
@@ -36,9 +50,38 @@ class Theme implements ThemeInterface
     }
 
     /**
-     * Get a color by name
+     * Create a theme from the five named roles.
+     */
+    public static function fromRoles(
+        ColorInterface $primary,
+        ColorInterface $secondary,
+        ColorInterface $accent,
+        ColorInterface $background,
+        ColorInterface $surface,
+    ): self {
+        return new self([
+            'primary' => $primary,
+            'secondary' => $secondary,
+            'accent' => $accent,
+            'background' => $background,
+            'surface' => $surface,
+        ]);
+    }
+
+    /**
+     * Lift a role-keyed palette (e.g. WebsiteThemeStrategy output) into a theme.
      *
-     * @throws InvalidArgumentException
+     * @throws InvalidArgumentException If the palette does not define all five roles
+     */
+    public static function fromPalette(ColorPaletteInterface $palette): self
+    {
+        return new self($palette->getColors());
+    }
+
+    /**
+     * Get a color by name.
+     *
+     * @throws InvalidArgumentException If the name is not present in the theme
      */
     public function getColor(string $name): ColorInterface
     {
@@ -50,7 +93,7 @@ class Theme implements ThemeInterface
     }
 
     /**
-     * Check if a color exists in the theme
+     * Check if a color exists in the theme.
      */
     public function hasColor(string $name): bool
     {
@@ -58,7 +101,7 @@ class Theme implements ThemeInterface
     }
 
     /**
-     * Get all colors in the theme
+     * Get all colors in the theme.
      *
      * @return array<string, ColorInterface>
      */
@@ -68,7 +111,7 @@ class Theme implements ThemeInterface
     }
 
     /**
-     * Convert theme to array
+     * Convert theme to a role => hex array.
      *
      * @return array<string, string>
      */
@@ -82,43 +125,28 @@ class Theme implements ThemeInterface
         return $result;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getPrimaryColor(): ColorInterface
     {
-        return $this->getColor('primary');
+        return $this->colors['primary'];
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getSecondaryColor(): ColorInterface
     {
-        return $this->getColor('secondary');
+        return $this->colors['secondary'];
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getAccentColor(): ColorInterface
     {
-        return $this->getColor('accent');
+        return $this->colors['accent'];
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getBackgroundColor(): ColorInterface
     {
-        return $this->getColor('background');
+        return $this->colors['background'];
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getSurfaceColor(): ColorInterface
     {
-        return $this->getColor('surface');
+        return $this->colors['surface'];
     }
 }

--- a/src/ThemeGenerator.php
+++ b/src/ThemeGenerator.php
@@ -12,29 +12,52 @@ use InvalidArgumentException;
 class ThemeGenerator implements ThemeGeneratorInterface
 {
     /**
-     * Generate a theme from a color palette
+     * Generate a theme from a color palette.
      *
-     * @param  array<string>  $colorNames  Optional color names for theme colors
+     * If the palette is already keyed by the five theme roles (e.g. the output of
+     * WebsiteThemeStrategy), it is lifted directly. Otherwise the five roles are
+     * derived from the palette: the dominant colors become primary/secondary/accent
+     * and neutral light tones are used for background/surface. The result always
+     * defines all five roles, so every ThemeInterface getter resolves.
      *
-     * @throws InvalidArgumentException
+     * @throws InvalidArgumentException If the palette is empty
      */
-    public function generate(ColorPaletteInterface $palette, array $colorNames = []): ThemeInterface
+    public function generate(ColorPaletteInterface $palette): ThemeInterface
     {
         $colors = $palette->getColors();
 
-        if (empty($colorNames)) {
-            $colorNames = ['primary', 'secondary', 'accent'];
+        // Already a role-keyed palette -> lift straight into a validated Theme.
+        $hasAllRoles = true;
+        foreach (Theme::ROLES as $role) {
+            if (! isset($colors[$role])) {
+                $hasAllRoles = false;
+                break;
+            }
         }
 
-        if (count($colors) !== count($colorNames)) {
-            throw new InvalidArgumentException('Number of colors in palette does not match number of color names');
+        if ($hasAllRoles) {
+            return Theme::fromPalette($palette);
         }
 
-        $themeColors = [];
-        foreach ($colors as $index => $color) {
-            $themeColors[$colorNames[$index]] = $color;
+        // Derive the five roles from an arbitrary palette. Pairing is positional
+        // (array_values), never key-based, so string- or gap-keyed palettes cannot
+        // corrupt the result.
+        $values = array_values($colors);
+
+        if ($values === []) {
+            throw new InvalidArgumentException('Cannot generate a theme from an empty palette');
         }
 
-        return Theme::fromColors($themeColors);
+        $primary = $values[0];
+        $secondary = $values[1] ?? $primary;
+        $accent = $values[2] ?? $secondary;
+
+        return Theme::fromRoles(
+            $primary,
+            $secondary,
+            $accent,
+            Color::fromHsl(0, 0, 98),  // near-white background
+            Color::fromHsl(0, 0, 100), // white surface
+        );
     }
 }

--- a/tests/Integration/PaletteGenerationWorkflowTest.php
+++ b/tests/Integration/PaletteGenerationWorkflowTest.php
@@ -279,11 +279,14 @@ describe('Image to Theme Workflow', function () {
             ->build();
 
         $themeGenerator = new ThemeGenerator;
-        $theme = $themeGenerator->generate($palette, ['primary', 'secondary', 'accent', 'background', 'surface']);
+        $theme = $themeGenerator->generate($palette);
 
         expect($theme)->toBeInstanceOf(Theme::class);
         expect($theme->getPrimaryColor())->toBeInstanceOf(Color::class);
         expect($theme->getSecondaryColor())->toBeInstanceOf(Color::class);
+        // All five roles resolve now (background/surface no longer throw).
+        expect($theme->getBackgroundColor())->toBeInstanceOf(Color::class);
+        expect($theme->getSurfaceColor())->toBeInstanceOf(Color::class);
     });
 
     test('it can create theme with convenience methods', function () {
@@ -298,7 +301,7 @@ describe('Image to Theme Workflow', function () {
             ->build();
 
         $themeGenerator = new ThemeGenerator;
-        $theme = $themeGenerator->generate($palette, ['primary', 'secondary', 'accent']);
+        $theme = $themeGenerator->generate($palette);
 
         $primary = $theme->getPrimaryColor();
         $secondary = $theme->getSecondaryColor();

--- a/tests/Unit/ThemeGeneratorTest.php
+++ b/tests/Unit/ThemeGeneratorTest.php
@@ -2,46 +2,44 @@
 
 use Farzai\ColorPalette\Color;
 use Farzai\ColorPalette\ColorPalette;
+use Farzai\ColorPalette\Strategies\WebsiteThemeStrategy;
 use Farzai\ColorPalette\ThemeGenerator;
 
-test('it can generate theme from color palette', function () {
+test('it derives a complete five-role theme from an arbitrary extraction palette', function () {
+    // A typical 5-colour extraction palette (plain indexed keys). This used to
+    // throw a count-mismatch and never produced background/surface roles.
     $palette = new ColorPalette([
-        new Color(255, 0, 0),
-        new Color(0, 255, 0),
-        new Color(0, 0, 255),
+        new Color(200, 30, 30),
+        new Color(30, 200, 30),
+        new Color(30, 30, 200),
+        new Color(200, 200, 30),
+        new Color(30, 200, 200),
     ]);
 
-    $generator = new ThemeGenerator;
-    $theme = $generator->generate($palette);
+    $theme = (new ThemeGenerator)->generate($palette);
 
-    expect($theme->getColors())->toHaveCount(3);
-    expect($theme->hasColor('primary'))->toBeTrue();
-    expect($theme->hasColor('secondary'))->toBeTrue();
-    expect($theme->hasColor('accent'))->toBeTrue();
+    // Every one of the five role getters resolves (previously background/surface threw).
+    expect($theme->getPrimaryColor())->toBeInstanceOf(Color::class);
+    expect($theme->getSecondaryColor())->toBeInstanceOf(Color::class);
+    expect($theme->getAccentColor())->toBeInstanceOf(Color::class);
+    expect($theme->getBackgroundColor())->toBeInstanceOf(Color::class);
+    expect($theme->getSurfaceColor())->toBeInstanceOf(Color::class);
+    expect($theme->getPrimaryColor()->toHex())->toBe('#c81e1e'); // first palette colour
 });
 
-test('it can generate theme with custom color names', function () {
-    $palette = new ColorPalette([
-        new Color(255, 0, 0),
-        new Color(0, 255, 0),
-    ]);
+test('it lifts a role-keyed palette (WebsiteThemeStrategy output) into a theme without corruption', function () {
+    // String-keyed palettes previously corrupted (key-vs-index pairing): undefined
+    // keys, dropped colours, an empty-string key. fromPalette must lift them cleanly.
+    $palette = (new WebsiteThemeStrategy)->generate(new Color(33, 150, 243));
 
-    $generator = new ThemeGenerator;
-    $theme = $generator->generate($palette, ['background', 'foreground']);
+    $theme = (new ThemeGenerator)->generate($palette);
 
-    expect($theme->getColors())->toHaveCount(2);
-    expect($theme->hasColor('background'))->toBeTrue();
-    expect($theme->hasColor('foreground'))->toBeTrue();
+    expect($theme->getColors())->toHaveCount(5);
+    expect($theme->getSurfaceColor()->toHex())->toBe('#ffffff');
+    expect($theme->getPrimaryColor()->toHex())->toBe($palette['primary']->toHex());
 });
 
-test('it throws exception when color names count does not match palette size', function () {
-    $palette = new ColorPalette([
-        new Color(255, 0, 0),
-        new Color(0, 255, 0),
-    ]);
-
-    $generator = new ThemeGenerator;
-
-    expect(fn () => $generator->generate($palette, ['background']))
+test('it throws on an empty palette', function () {
+    expect(fn () => (new ThemeGenerator)->generate(new ColorPalette([])))
         ->toThrow(InvalidArgumentException::class);
 });

--- a/tests/Unit/ThemeTest.php
+++ b/tests/Unit/ThemeTest.php
@@ -1,146 +1,75 @@
 <?php
 
 use Farzai\ColorPalette\Color;
+use Farzai\ColorPalette\ColorPalette;
 use Farzai\ColorPalette\Theme;
 
-test('it can create theme from colors', function () {
-    $theme = Theme::fromColors([
+/**
+ * @return array<string, Color>
+ */
+function themeRoleColors(): array
+{
+    return [
         'primary' => new Color(255, 0, 0),
         'secondary' => new Color(0, 255, 0),
         'accent' => new Color(0, 0, 255),
-    ]);
+        'background' => new Color(250, 250, 250),
+        'surface' => new Color(255, 255, 255),
+    ];
+}
 
-    expect($theme->getColor('primary')->toHex())->toBe('#ff0000');
-    expect($theme->getColor('secondary')->toHex())->toBe('#00ff00');
-    expect($theme->getColor('accent')->toHex())->toBe('#0000ff');
+test('it builds a theme from the five named roles', function () {
+    $theme = Theme::fromRoles(
+        new Color(255, 0, 0),
+        new Color(0, 255, 0),
+        new Color(0, 0, 255),
+        new Color(250, 250, 250),
+        new Color(255, 255, 255),
+    );
+
+    expect($theme->getPrimaryColor()->toHex())->toBe('#ff0000');
+    expect($theme->getSecondaryColor()->toHex())->toBe('#00ff00');
+    expect($theme->getAccentColor()->toHex())->toBe('#0000ff');
+    expect($theme->getBackgroundColor()->toHex())->toBe('#fafafa');
+    expect($theme->getSurfaceColor()->toHex())->toBe('#ffffff');
 });
 
-test('it can get all colors', function () {
-    $theme = Theme::fromColors([
+test('all five role getters resolve without throwing on a valid theme', function () {
+    $theme = Theme::fromColors(themeRoleColors());
+
+    foreach (['getPrimaryColor', 'getSecondaryColor', 'getAccentColor', 'getBackgroundColor', 'getSurfaceColor'] as $getter) {
+        expect($theme->{$getter}())->toBeInstanceOf(Color::class);
+    }
+});
+
+test('it throws when a required role is missing', function () {
+    expect(fn () => Theme::fromColors([
         'primary' => new Color(255, 0, 0),
         'secondary' => new Color(0, 255, 0),
-    ]);
-
-    expect($theme->getColors())->toHaveCount(2);
-    expect($theme->getColors())->toHaveKey('primary');
-    expect($theme->getColors())->toHaveKey('secondary');
+        'accent' => new Color(0, 0, 255),
+        // background + surface missing
+    ]))->toThrow(InvalidArgumentException::class);
 });
 
-test('it can check if color exists', function () {
-    $theme = Theme::fromColors([
-        'primary' => new Color(255, 0, 0),
-    ]);
+test('it lifts a role-keyed palette into a theme via fromPalette', function () {
+    $theme = Theme::fromPalette(new ColorPalette(themeRoleColors()));
+
+    expect($theme->getSurfaceColor()->toHex())->toBe('#ffffff');
+    expect($theme->getColors())->toHaveCount(5);
+});
+
+test('it can check role presence and export to a hex array', function () {
+    $theme = Theme::fromColors(themeRoleColors());
 
     expect($theme->hasColor('primary'))->toBeTrue();
-    expect($theme->hasColor('secondary'))->toBeFalse();
+    expect($theme->hasColor('non-existent'))->toBeFalse();
+    expect($theme->toArray())->toHaveKey('surface', '#ffffff');
+    expect($theme->getColors())->toHaveCount(5);
 });
 
-test('it throws exception when getting non-existent color', function () {
-    $theme = Theme::fromColors([
-        'primary' => new Color(255, 0, 0),
-    ]);
+test('getColor throws for an unknown role name', function () {
+    $theme = Theme::fromColors(themeRoleColors());
 
     expect(fn () => $theme->getColor('non-existent'))
         ->toThrow(InvalidArgumentException::class);
-});
-
-test('it can convert theme to array', function () {
-    $theme = Theme::fromColors([
-        'primary' => new Color(255, 0, 0),
-        'secondary' => new Color(0, 255, 0),
-    ]);
-
-    expect($theme->toArray())->toBe([
-        'primary' => '#ff0000',
-        'secondary' => '#00ff00',
-    ]);
-});
-
-describe('Theme Convenience Methods', function () {
-    test('it can get primary color', function () {
-        $theme = Theme::fromColors([
-            'primary' => new Color(255, 0, 0),
-            'secondary' => new Color(0, 255, 0),
-        ]);
-
-        expect($theme->getPrimaryColor()->toHex())->toBe('#ff0000');
-    });
-
-    test('it can get secondary color', function () {
-        $theme = Theme::fromColors([
-            'primary' => new Color(255, 0, 0),
-            'secondary' => new Color(0, 255, 0),
-        ]);
-
-        expect($theme->getSecondaryColor()->toHex())->toBe('#00ff00');
-    });
-
-    test('it can get accent color', function () {
-        $theme = Theme::fromColors([
-            'accent' => new Color(0, 0, 255),
-        ]);
-
-        expect($theme->getAccentColor()->toHex())->toBe('#0000ff');
-    });
-
-    test('it can get background color', function () {
-        $theme = Theme::fromColors([
-            'background' => new Color(240, 240, 240),
-        ]);
-
-        expect($theme->getBackgroundColor()->toHex())->toBe('#f0f0f0');
-    });
-
-    test('it can get surface color', function () {
-        $theme = Theme::fromColors([
-            'surface' => new Color(255, 255, 255),
-        ]);
-
-        expect($theme->getSurfaceColor()->toHex())->toBe('#ffffff');
-    });
-
-    test('it throws exception when getting primary color without primary key', function () {
-        $theme = Theme::fromColors([
-            'secondary' => new Color(0, 255, 0),
-        ]);
-
-        expect(fn () => $theme->getPrimaryColor())
-            ->toThrow(InvalidArgumentException::class, "Color 'primary' not found in theme");
-    });
-
-    test('it throws exception when getting secondary color without secondary key', function () {
-        $theme = Theme::fromColors([
-            'primary' => new Color(255, 0, 0),
-        ]);
-
-        expect(fn () => $theme->getSecondaryColor())
-            ->toThrow(InvalidArgumentException::class, "Color 'secondary' not found in theme");
-    });
-
-    test('it throws exception when getting accent color without accent key', function () {
-        $theme = Theme::fromColors([
-            'primary' => new Color(255, 0, 0),
-        ]);
-
-        expect(fn () => $theme->getAccentColor())
-            ->toThrow(InvalidArgumentException::class, "Color 'accent' not found in theme");
-    });
-
-    test('it throws exception when getting background color without background key', function () {
-        $theme = Theme::fromColors([
-            'primary' => new Color(255, 0, 0),
-        ]);
-
-        expect(fn () => $theme->getBackgroundColor())
-            ->toThrow(InvalidArgumentException::class, "Color 'background' not found in theme");
-    });
-
-    test('it throws exception when getting surface color without surface key', function () {
-        $theme = Theme::fromColors([
-            'primary' => new Color(255, 0, 0),
-        ]);
-
-        expect(fn () => $theme->getSurfaceColor())
-            ->toThrow(InvalidArgumentException::class, "Color 'surface' not found in theme");
-    });
 });


### PR DESCRIPTION
Unifies the theme subsystem (the focused theme review's full Option A). Addresses the confirmed contract bugs and the fragmentation, before tagging 2.0.0.

## Bugs fixed
- **2 of 5 ThemeInterface getters threw on ThemeGenerator's own output** — `getBackgroundColor()`/`getSurfaceColor()` threw because the default only populated primary/secondary/accent.
- **ThemeGenerator paired colors→names by array KEY, not position** — string-/gap-keyed palettes (WebsiteThemeStrategy, getSuggestedSurfaceColors output) silently corrupted (undefined-key warnings, empty keys, dropped colors).
- **Strict `count(colors)===count(names)`** rejected the typical 5-color extraction palette.
- **`ThemeGenerator::generate()` signature diverged** from `ThemeGeneratorInterface` (extra `$colorNames`).

## Design
- `Theme` is now a **validated 5-role value object** (primary/secondary/accent/background/surface). Constructor + `fromColors()` throw if a role is missing; the five getters never throw. New `Theme::fromRoles(...)` and `Theme::fromPalette($palette)` (the bridge that lifts `WebsiteThemeStrategy`'s role-keyed palette into a `Theme`).
- `ThemeGenerator::generate($palette)` matches the interface, lifts role-keyed palettes, else derives all five roles positionally (`array_values`).
- Docs: typed-`Theme` README section + fixed the surface/"Primary" mislabel; UPGRADING §6.

## Deferred to 2.1 (non-breaking, noted in the review)
accent-math fix (`findAccentColor` dual-contrast), `createVariant` HSL, `WebsiteThemeStrategy` achromatic hardening, `getSuggestedSurfaceColors` de-dup.

## Verification
- `composer test` → 961 passed, 40 skipped (Theme/ThemeGenerator tests rewritten; integration test updated)
- `composer analyse` → No errors (level 6); `composer format` → clean

**BREAKING CHANGE:** `Theme` requires the five roles; `ThemeGenerator::generate()` drops `$colorNames`.