### PR TITLE
chore: exclude /assets from the distributed package

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -10,6 +10,7 @@
 /CONTRIBUTING.md export-ignore
 /CONTRIBUTORS.md export-ignore
 /UPGRADING.md export-ignore
+/assets export-ignore
 /example export-ignore
 /phpstan.neon.dist export-ignore
 /phpunit.xml.dist export-ignore


### PR DESCRIPTION
Follow-up to the dist-slimming in #42 (which export-ignored `example/`, `tests/`, dev configs, etc.).

`assets/sample.jpg` (8 KB) is a demo image referenced only by `example/03` and `example/06` (both already excluded) and never used by `src/` at runtime — so it shipped to every `composer require` for no reason.

`git archive HEAD` after this change — the dist's non-`src/` files are exactly:
```
CHANGELOG.md  LICENSE.md  README.md  composer.json
```
No code change; affects only the packaged tarball (working tree / examples unaffected).