### PR TITLE
fix(example): web-ui API always returns JSON (fixes broken file upload)

### DIFF
--- a/example/web-ui/api.php
+++ b/example/web-ui/api.php
@@ -8,6 +8,23 @@ use Farzai\ColorPalette\ColorPalette;
 use Farzai\ColorPalette\Config\HttpClientConfig;
 use Farzai\ColorPalette\ImageLoaderFactory;
 
+// Always respond with JSON. Never let a PHP notice/warning/deprecation print into
+// the body (it would prepend HTML like "<br /><b>Deprecated</b>…" and break the
+// front-end's response.json()). Errors are logged, not echoed; fatals are trapped
+// on shutdown and returned as JSON.
+ini_set('display_errors', '0');
+
+register_shutdown_function(function (): void {
+    $err = error_get_last();
+    if ($err !== null && in_array($err['type'], [E_ERROR, E_PARSE, E_CORE_ERROR, E_COMPILE_ERROR], true)) {
+        if (! headers_sent()) {
+            http_response_code(500);
+            header('Content-Type: application/json');
+        }
+        echo json_encode(['success' => false, 'error' => 'Server error: '.$err['message']]);
+    }
+});
+
 // Enable CORS for local development
 header('Access-Control-Allow-Origin: *');
 header('Access-Control-Allow-Methods: POST, GET, OPTIONS');
@@ -44,7 +61,7 @@ try {
         default:
             throw new Exception('Invalid action');
     }
-} catch (Exception $e) {
+} catch (Throwable $e) {
     http_response_code(400);
     echo json_encode([
         'success' => false,
@@ -124,7 +141,7 @@ function handleExtract()
             $allowedTypes = ['image/jpeg', 'image/png', 'image/gif', 'image/webp'];
             $finfo = finfo_open(FILEINFO_MIME_TYPE);
             $mimeType = finfo_file($finfo, $file['tmp_name']);
-            finfo_close($finfo);
+            // finfo_close() is deprecated as of PHP 8.5 (the object frees itself).
 
             if (! in_array($mimeType, $allowedTypes)) {
                 throw new Exception('Invalid file type. Allowed: JPEG, PNG, GIF, WebP');


### PR DESCRIPTION
Reported: uploading an image in the redesigned demo failed with **`Unexpected token '<', "<br /> <b>"... is not valid JSON`**.

## Root cause
On **PHP 8.5**, `finfo_close()` is deprecated. The `php -S` dev server printed that deprecation as **HTML** (`<br /><b>Deprecated</b>: …`) *before* the JSON body, so the front-end's `response.json()` choked on the leading `<`. The extraction itself succeeded — the response was just prefixed with an HTML notice. (Only the **file-upload** path calls `finfo_close`, so the URL/picsum path I tested earlier didn't surface it.)

## Fix
- Remove the deprecated `finfo_close()` call.
- Harden `api.php` to **always emit JSON**: `display_errors=0` (notices logged, not echoed), `catch (\Throwable)` instead of `\Exception`, and a shutdown handler that returns a JSON 500 on fatals — so no stray PHP output can ever corrupt the response again.

## Verified (real browser, Playwright)
Uploaded a PNG and a JPG → extracts and renders (swatches + suggested roles + showcase) with **0 console errors**; an invalid file returns a clean JSON error (`Invalid file type…`). Also re-checked via curl that uploads return pure JSON (first byte `{`).